### PR TITLE
Now we get rid of error: "lvalue required as left operand of assignment"

### DIFF
--- a/Makefile.pref
+++ b/Makefile.pref
@@ -23,7 +23,7 @@ ifeq (x$(GSKIT), x)
 GSKIT = $(PS2DEV)/gsKit
 endif
 
-#GCCLIB = $(PS2DEV)/ee/lib/gcc-lib/ee/3.2.2
+#GCCLIB = $(PS2DEV)/ee/lib/gcc-lib/ee/3.2.3
 #CPPLIB = $(PS2DEV)/ee/ee/lib
 
 LIBGSKIT = $(GSKITSRC)/lib/libgskit.a

--- a/ee/gs/src/gsCore.c
+++ b/ee/gs/src/gsCore.c
@@ -75,7 +75,7 @@ void gsKit_setactive(GSGLOBAL *gsGlobal)
 	u64 *p_data;
 	u64 *p_store;
 
-	(u32)p_data = (u32)p_store = gsGlobal->dma_misc;
+	p_data = p_store = (u64 *)gsGlobal->dma_misc;
 
 	*p_data++ = GIF_TAG( 4, 1, 0, 0, 0, 1 );
 	*p_data++ = GIF_AD;

--- a/ee/gs/src/gsFontM.c
+++ b/ee/gs/src/gsFontM.c
@@ -157,7 +157,7 @@ int gsKit_fontm_unpack(GSFONTM *gsFontM)
 	gsFontM->Header.offset_table = malloc(TableSize);
 
 	u8 *temp;
-	(u32)temp = ((u32)unpacked + gsFontM->Header.baseoffset + 17680);
+	temp = (u8 *)((u32)unpacked + gsFontM->Header.baseoffset + 17680);
 
 	int TexSize = (338 * gsFontM->Header.num_entries);
 

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -259,7 +259,7 @@ void gsKit_init_screen(GSGLOBAL *gsGlobal)
 
     gsGlobal->TexturePointer = gsGlobal->CurrentPointer; // first useable address for textures
 
-	(u32)p_data = (u32)p_store = gsGlobal->dma_misc;
+	p_data = p_store = (u64 *)gsGlobal->dma_misc;
 
 	*p_data++ = GIF_TAG( size - 1, 1, 0, 0, 0, 1 );
 	*p_data++ = GIF_AD;
@@ -389,7 +389,7 @@ GSGLOBAL *gsKit_init_global_custom(int Os_AllocSize, int Per_AllocSize)
 	gsGlobal->Clamp = calloc(1,sizeof(GSCLAMP));
 	gsGlobal->Os_Queue = calloc(1,sizeof(GSQUEUE));
 	gsGlobal->Per_Queue = calloc(1,sizeof(GSQUEUE));
-	(u32)gsGlobal->dma_misc = ((u32)memalign(64, 512) | 0x30000000);
+	gsGlobal->dma_misc = (u64 *)((u32)memalign(64, 512) | 0x30000000);
 
 	/* Generic Values */
 	if(configGetTvScreenType() == 2) gsGlobal->Aspect = GS_ASPECT_16_9;
@@ -419,11 +419,11 @@ GSGLOBAL *gsKit_init_global_custom(int Os_AllocSize, int Per_AllocSize)
 	gsGlobal->EvenOrOdd = 0;
 
 	gsGlobal->Os_AllocSize = Os_AllocSize;
-	(u32)gsGlobal->Os_Queue->dma_tag = (u32)gsGlobal->Os_Queue->pool[0] = ((u32)memalign(64, Os_AllocSize) | 0x30000000);
-	(u32)gsGlobal->Os_Queue->pool[1] = ((u32)memalign(64, Os_AllocSize) | 0x30000000);
-	(u32)gsGlobal->Os_Queue->pool_cur = ((u32)gsGlobal->Os_Queue->pool[0] + 16);
-	(u32)gsGlobal->Os_Queue->pool_max[0] = ((u32)gsGlobal->Os_Queue->pool[0] + Os_AllocSize);
-	(u32)gsGlobal->Os_Queue->pool_max[1] = ((u32)gsGlobal->Os_Queue->pool[1] + Os_AllocSize);
+	gsGlobal->Os_Queue->dma_tag = gsGlobal->Os_Queue->pool[0] = (u64 *)((u32)memalign(64, Os_AllocSize) | 0x30000000);
+	gsGlobal->Os_Queue->pool[1] = (u64 *)((u32)memalign(64, Os_AllocSize) | 0x30000000);
+	gsGlobal->Os_Queue->pool_cur = (u64 *)((u32)gsGlobal->Os_Queue->pool[0] + 16);
+	gsGlobal->Os_Queue->pool_max[0] = (u64 *)((u32)gsGlobal->Os_Queue->pool[0] + Os_AllocSize);
+	gsGlobal->Os_Queue->pool_max[1] = (u64 *)((u32)gsGlobal->Os_Queue->pool[1] + Os_AllocSize);
 	gsGlobal->Os_Queue->dbuf = 0;
 	gsGlobal->Os_Queue->tag_size = 0;
 	gsGlobal->Os_Queue->last_tag = gsGlobal->Os_Queue->pool_cur;
@@ -431,9 +431,9 @@ GSGLOBAL *gsKit_init_global_custom(int Os_AllocSize, int Per_AllocSize)
 	gsGlobal->Os_Queue->mode = GS_ONESHOT;
 
 	gsGlobal->Per_AllocSize = Per_AllocSize;
-	(u32)gsGlobal->Per_Queue->dma_tag = (u32)gsGlobal->Per_Queue->pool[0] = ((u32)memalign(64, Per_AllocSize) | 0x30000000);
-	(u32)gsGlobal->Per_Queue->pool_cur = ((u32)gsGlobal->Per_Queue->pool[0] + 16);
-	(u32)gsGlobal->Per_Queue->pool_max[0] = ((u32)gsGlobal->Per_Queue->pool[0] + Per_AllocSize);
+	gsGlobal->Per_Queue->dma_tag = gsGlobal->Per_Queue->pool[0] = (u64 *)((u32)memalign(64, Per_AllocSize) | 0x30000000);
+	gsGlobal->Per_Queue->pool_cur = (u64 *)((u32)gsGlobal->Per_Queue->pool[0] + 16);
+	gsGlobal->Per_Queue->pool_max[0] = (u64 *)((u32)gsGlobal->Per_Queue->pool[0] + Per_AllocSize);
 	gsGlobal->Per_Queue->dbuf = 0;
 	gsGlobal->Per_Queue->tag_size = 0;
 	gsGlobal->Per_Queue->last_tag = gsGlobal->Per_Queue->pool_cur;
@@ -484,10 +484,10 @@ GSGLOBAL *gsKit_init_global_custom(int Os_AllocSize, int Per_AllocSize)
 
 void gsKit_deinit_global(GSGLOBAL *gsGlobal)
 {
-    (u32)gsGlobal->Per_Queue->pool[0] ^= 0x30000000;
-    (u32)gsGlobal->Os_Queue->pool[1] ^= 0x30000000;
-    (u32)gsGlobal->Os_Queue->pool[0] ^= 0x30000000;
-    (u32)gsGlobal->dma_misc ^= 0x30000000;
+    gsGlobal->Per_Queue->pool[0] = (u64 *)((u32)gsGlobal->Per_Queue->pool[0] ^ 0x30000000);
+    gsGlobal->Os_Queue->pool[1] = (u64 *)((u32)gsGlobal->Os_Queue->pool[1] ^ 0x30000000);
+    gsGlobal->Os_Queue->pool[0] = (u64 *)((u32)gsGlobal->Os_Queue->pool[0] ^ 0x30000000);
+    gsGlobal->dma_misc = (u64 *)((u32)gsGlobal->dma_misc ^ 0x30000000);
 
     free(gsGlobal->Per_Queue->pool[0]);
     free(gsGlobal->Os_Queue->pool[1]);

--- a/examples/linuz-texture/texture.c
+++ b/examples/linuz-texture/texture.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 	tex.Width = 256;
 	tex.Height = 256;
 	tex.PSM = GS_PSM_CT24;
-	(char*)tex.Mem = testorig;
+	tex.Mem = (void *)testorig;
 	tex.Vram = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(tex.Width, tex.Height, tex.PSM), GSKIT_ALLOC_USERBUFFER);
 	tex.Filter = GS_FILTER_LINEAR;
 	gsKit_texture_upload(gsGlobal, &tex);
@@ -52,7 +52,7 @@ int main(int argc, char *argv[])
 	tex8.Width = 256;
 	tex8.Height = 256;
 	tex8.PSM = GS_PSM_T8;
-	(unsigned char*)tex8.Mem = image_pixel;
+	tex8.Mem = (void *)image_pixel;
 	tex8.Vram = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(tex8.Width, tex8.Height, tex8.PSM), GSKIT_ALLOC_USERBUFFER);
 	tex8.Clut = image_clut32;
 	tex8.ClutPSM = GS_PSM_CT32;


### PR DESCRIPTION
I hope that all my fixes are normal. All pointers points to u64 (except of one). Those 2 lines from texture.c really points to u32 (u32 *Mem;		///< EE Memory Pointer)