### PR TITLE
Fixes and Additions

### DIFF
--- a/ee/gs/include/gsCore.h
+++ b/ee/gs/include/gsCore.h
@@ -138,6 +138,12 @@ int gsKit_add_vsync_handler(int (*vsync_callback)());
 /// Removes a vsync interrupt handler
 void gsKit_remove_vsync_handler(int callback_id);
 
+/// Installs a hsync interrupt handler (hblank_start)
+int gsKit_add_hsync_handler(int (*hsync_callback)());
+
+/// Removes a hsync interrupt handler
+void gsKit_remove_hsync_handler(int callback_id);
+
 /// Sets gsGlobal->EvenOrOdd depending on current field drawing
 void gsKit_get_field(GSGLOBAL *gsGlobal);
 

--- a/ee/gs/include/gsCore.h
+++ b/ee/gs/include/gsCore.h
@@ -206,7 +206,16 @@ void gsKit_queue_exec(GSGLOBAL *gsGlobal);
 /// Specific Draw Queue "Execution" (Kicks the Queue passed for the second argument)
 void gsKit_queue_exec_real(GSGLOBAL *gsGlobal, GSQUEUE *Queue);
 
-/// Switch Current Draw Queue (Between GS_ONESHOT and GS_PERSISTENT)
+/// Initialize a Draw Queue (Allocates memory for the Queue)
+void gsKit_queue_init(GSGLOBAL *gsGlobal, GSQUEUE *Queue, u8 mode, int size);
+
+/// Free Allocated Memory for Draw Queue
+void gsKit_queue_free(GSGLOBAL *gsGlobal, GSQUEUE *Queue);
+
+/// Set Current Draw Queue
+void gsKit_queue_set(GSGLOBAL *gsGlobal, GSQUEUE *Queue);
+
+/// Set Current Draw Queue (Between GS_ONESHOT and GS_PERSISTENT)
 void gsKit_mode_switch(GSGLOBAL *gsGlobal, u8 mode);
 
 #ifdef __cplusplus

--- a/ee/gs/include/gsInit.h
+++ b/ee/gs/include/gsInit.h
@@ -994,8 +994,10 @@ struct gsGlobal
 	int Aspect;          ///< Framebuffer Aspect Ratio (GS_ASPECT_4_3/GS_ASPECT_16_9)
 	int OffsetX;         ///< X Window Offset
 	int OffsetY;         ///< Y Window Offset
-	int StartX;          ///< X Starting Coordinate (Used for Placement Correction)
-	int StartY;          ///< Y Starting Coordinate (Used for Placement Correction)
+	int StartX;          ///< X Starting Coordinate (Used for Placement Correction) Default value
+	int StartY;          ///< Y Starting Coordinate (Used for Placement Correction) Default value
+	int StartXOffset;    ///< X Starting Coordinate (Used for Placement Correction) Additional correction
+	int StartYOffset;    ///< Y Starting Coordinate (Used for Placement Correction) Additional correction
 	int MagH;            ///< X Magnification Value (MAGH = DW / Width - 1)
 	int MagV;            ///< Y Magnification Value (MAGV = DH / Height - 1)
 	int DW;              ///< Total Display Area Width (DW = Width * (MAGH + 1))

--- a/ee/gs/include/gsInline.h
+++ b/ee/gs/include/gsInline.h
@@ -31,7 +31,7 @@ static inline void *gsKit_heap_alloc(GSGLOBAL *gsGlobal, int qsize, int bsize, i
 		*(u64 *)gsGlobal->CurQueue->dma_tag = DMA_TAG(gsGlobal->CurQueue->tag_size, 0, DMA_CNT, 0, 0, 0);
 		gsGlobal->CurQueue->tag_size = 0;
 		gsGlobal->CurQueue->dma_tag = gsGlobal->CurQueue->pool_cur;
-		gsGlobal->CurQueue->pool_cur += 16;
+		(u8*)gsGlobal->CurQueue->pool_cur += 16;
 	}
 
 	if(type == GIF_AD || type != gsGlobal->CurQueue->last_type || gsGlobal->CurQueue->same_obj >= GS_GIF_BLOCKSIZE)
@@ -51,7 +51,7 @@ static inline void *gsKit_heap_alloc(GSGLOBAL *gsGlobal, int qsize, int bsize, i
 	gsGlobal->CurQueue->last_type = type;
 	gsGlobal->CurQueue->tag_size += qsize;
 	void *p_heap = gsGlobal->CurQueue->pool_cur;
-	gsGlobal->CurQueue->pool_cur += bsize;
+	(u8*)gsGlobal->CurQueue->pool_cur += bsize;
 
 	return p_heap;
 }
@@ -79,9 +79,9 @@ static inline void *gsKit_heap_alloc_dma(GSGLOBAL *gsGlobal, int qsize, int bsiz
 	gsGlobal->CurQueue->same_obj = 0;
 
 	void *p_heap = gsGlobal->CurQueue->pool_cur;
-	gsGlobal->CurQueue->pool_cur += bsize;
+	(u8*)gsGlobal->CurQueue->pool_cur += bsize;
 	gsGlobal->CurQueue->dma_tag = gsGlobal->CurQueue->pool_cur;
-	gsGlobal->CurQueue->pool_cur += 16;
+	(u8*)gsGlobal->CurQueue->pool_cur += 16;
 
 	return p_heap;
 }

--- a/ee/gs/src/gsCore.c
+++ b/ee/gs/src/gsCore.c
@@ -157,29 +157,13 @@ void gsKit_hsync_wait(void)
     while(!(*GS_CSR & 4));
 }
 
-/*
-enum
-{
-   kINTC_GS,
-   kINTC_SBUS,
-   kINTC_VBLANK_START,
-   kINTC_VBLANK_END,
-   kINTC_VIF0,
-   kINTC_VIF1,
-   kINTC_VU0,
-   kINTC_VU1,
-   kINTC_IPU,
-   kINTC_TIMER0,
-   kINTC_TIMER1
-};
-*/
 int gsKit_add_vsync_handler(int (*vsync_callback)())
 {
 	int callback_id;
 
 	DIntr();
-	callback_id = AddIntcHandler(2, vsync_callback, 0);
-	EnableIntc(kINTC_VBLANK_START);
+	callback_id = AddIntcHandler(INTC_VBLANK_S, vsync_callback, 0);
+	EnableIntc(INTC_VBLANK_S);
 	EIntr();
 
 	return callback_id;
@@ -188,8 +172,28 @@ int gsKit_add_vsync_handler(int (*vsync_callback)())
 void gsKit_remove_vsync_handler(int callback_id)
 {
 	DIntr();
-	DisableIntc(kINTC_VBLANK_START);
-	RemoveIntcHandler(2, callback_id);
+	DisableIntc(INTC_VBLANK_S);
+	RemoveIntcHandler(INTC_VBLANK_S, callback_id);
+	EIntr();
+}
+
+int gsKit_add_hsync_handler(int (*hsync_callback)())
+{
+	int callback_id;
+
+	DIntr();
+	callback_id = AddIntcHandler(INTC_GS, hsync_callback, 0);
+	EnableIntc(INTC_GS);
+	EIntr();
+
+	return callback_id;
+}
+
+void gsKit_remove_hsync_handler(int callback_id)
+{
+	DIntr();
+	DisableIntc(INTC_GS);
+	RemoveIntcHandler(INTC_GS, callback_id);
 	EIntr();
 }
 

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -41,6 +41,9 @@ void gsKit_set_buffer_attributes(GSGLOBAL *gsGlobal)
 {
 	int gs_DX, gs_DY, gs_DW, gs_DH;
 
+	gsGlobal->StartXOffset = 0;
+	gsGlobal->StartYOffset = 0;
+
 	switch (gsGlobal->Mode) {
 		case GS_MODE_NTSC:
 			gsGlobal->StartX = 492;
@@ -190,15 +193,20 @@ void gsKit_set_buffer_attributes(GSGLOBAL *gsGlobal)
 
 void gsKit_set_display_offset(GSGLOBAL *gsGlobal, int x, int y)
 {
-	GS_SET_DISPLAY1(gsGlobal->StartX+x,		// X position in the display area (in VCK unit
-			gsGlobal->StartY+y,		// Y position in the display area (in Raster u
+	gsGlobal->StartXOffset = x;
+	gsGlobal->StartYOffset = y;
+
+	GS_SET_DISPLAY1(
+			gsGlobal->StartX + gsGlobal->StartXOffset,	// X position in the display area (in VCK unit
+			gsGlobal->StartY + gsGlobal->StartYOffset,	// Y position in the display area (in Raster u
 			gsGlobal->MagH,			// Horizontal Magnification
 			gsGlobal->MagV,			// Vertical Magnification
 			gsGlobal->DW - 1,	// Display area width
 			gsGlobal->DH - 1);		// Display area height
 
-	GS_SET_DISPLAY2(gsGlobal->StartX+x,		// X position in the display area (in VCK units)
-			gsGlobal->StartY+y,		// Y position in the display area (in Raster units)
+	GS_SET_DISPLAY2(
+			gsGlobal->StartX + gsGlobal->StartXOffset,	// X position in the display area (in VCK units)
+			gsGlobal->StartY + gsGlobal->StartYOffset,	// Y position in the display area (in Raster units)
 			gsGlobal->MagH,			// Horizontal Magnification
 			gsGlobal->MagV,			// Vertical Magnification
 			gsGlobal->DW - 1,	// Display area width
@@ -273,15 +281,17 @@ void gsKit_init_screen(GSGLOBAL *gsGlobal)
 			0,			// Upper Left X in Buffer
 			0);			// Upper Left Y in Buffer
 
-	GS_SET_DISPLAY1(gsGlobal->StartX,		// X position in the display area (in VCK unit
-			gsGlobal->StartY,		// Y position in the display area (in Raster u
+	GS_SET_DISPLAY1(
+			gsGlobal->StartX + gsGlobal->StartXOffset,	// X position in the display area (in VCK unit
+			gsGlobal->StartY + gsGlobal->StartYOffset,	// Y position in the display area (in Raster u
 			gsGlobal->MagH,			// Horizontal Magnification
 			gsGlobal->MagV,			// Vertical Magnification
 			gsGlobal->DW - 1,	// Display area width
 			gsGlobal->DH - 1);		// Display area height
 
-	GS_SET_DISPLAY2(gsGlobal->StartX,		// X position in the display area (in VCK units)
-			gsGlobal->StartY,		// Y position in the display area (in Raster units)
+	GS_SET_DISPLAY2(
+			gsGlobal->StartX + gsGlobal->StartXOffset,	// X position in the display area (in VCK units)
+			gsGlobal->StartY + gsGlobal->StartYOffset,	// Y position in the display area (in Raster units)
 			gsGlobal->MagH,			// Horizontal Magnification
 			gsGlobal->MagV,			// Vertical Magnification
 			gsGlobal->DW - 1,	// Display area width

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -236,7 +236,7 @@ void gsKit_init_screen(GSGLOBAL *gsGlobal)
 
     *GS_CSR = 0x00000000; // Clean CSR registers
 
-    GsPutIMR(0x0000F700); // Unmasks all of the GS interrupts
+    GsPutIMR(0x00007300); // Unmasks VSync and HSync interrupts
 
 	SetGsCrt(gsGlobal->Interlace, gsGlobal->Mode, gsGlobal->Field);
 

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -320,7 +320,7 @@ void gsKit_init_screen(GSGLOBAL *gsGlobal)
 	*p_data++ = 1;
 	*p_data++ = GS_PRMODECONT;
 
-	*p_data++ = GS_SETREG_FRAME_1( gsGlobal->ScreenBuffer[0], gsGlobal->Width / 64, gsGlobal->PSM, 0 );
+	*p_data++ = GS_SETREG_FRAME_1( gsGlobal->ScreenBuffer[0] / 8192, gsGlobal->Width / 64, gsGlobal->PSM, 0 );
 	*p_data++ = GS_FRAME_1;
 
 	*p_data++ = GS_SETREG_XYOFFSET_1( gsGlobal->OffsetX,
@@ -362,7 +362,7 @@ void gsKit_init_screen(GSGLOBAL *gsGlobal)
 	*p_data++ = GS_SETREG_COLCLAMP( 255 );
 	*p_data++ = GS_COLCLAMP;
 
-	*p_data++ = GS_SETREG_FRAME_1( gsGlobal->ScreenBuffer[1], gsGlobal->Width / 64, gsGlobal->PSM, 0 );
+	*p_data++ = GS_SETREG_FRAME_1( gsGlobal->ScreenBuffer[1] / 8192, gsGlobal->Width / 64, gsGlobal->PSM, 0 );
 	*p_data++ = GS_FRAME_2;
 
 	*p_data++ = GS_SETREG_XYOFFSET_1( gsGlobal->OffsetX,

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -474,26 +474,10 @@ GSGLOBAL *gsKit_init_global_custom(int Os_AllocSize, int Per_AllocSize)
 	gsGlobal->EvenOrOdd = 0;
 
 	gsGlobal->Os_AllocSize = Os_AllocSize;
-	gsGlobal->Os_Queue->dma_tag = gsGlobal->Os_Queue->pool[0] = (u64 *)((u32)memalign(64, Os_AllocSize) | 0x30000000);
-	gsGlobal->Os_Queue->pool[1] = (u64 *)((u32)memalign(64, Os_AllocSize) | 0x30000000);
-	gsGlobal->Os_Queue->pool_cur = (u64 *)((u32)gsGlobal->Os_Queue->pool[0] + 16);
-	gsGlobal->Os_Queue->pool_max[0] = (u64 *)((u32)gsGlobal->Os_Queue->pool[0] + Os_AllocSize);
-	gsGlobal->Os_Queue->pool_max[1] = (u64 *)((u32)gsGlobal->Os_Queue->pool[1] + Os_AllocSize);
-	gsGlobal->Os_Queue->dbuf = 0;
-	gsGlobal->Os_Queue->tag_size = 0;
-	gsGlobal->Os_Queue->last_tag = gsGlobal->Os_Queue->pool_cur;
-	gsGlobal->Os_Queue->last_type = GIF_RESERVED;
-	gsGlobal->Os_Queue->mode = GS_ONESHOT;
+	gsKit_queue_init(gsGlobal, gsGlobal->Os_Queue, GS_ONESHOT, Os_AllocSize);
 
 	gsGlobal->Per_AllocSize = Per_AllocSize;
-	gsGlobal->Per_Queue->dma_tag = gsGlobal->Per_Queue->pool[0] = (u64 *)((u32)memalign(64, Per_AllocSize) | 0x30000000);
-	gsGlobal->Per_Queue->pool_cur = (u64 *)((u32)gsGlobal->Per_Queue->pool[0] + 16);
-	gsGlobal->Per_Queue->pool_max[0] = (u64 *)((u32)gsGlobal->Per_Queue->pool[0] + Per_AllocSize);
-	gsGlobal->Per_Queue->dbuf = 0;
-	gsGlobal->Per_Queue->tag_size = 0;
-	gsGlobal->Per_Queue->last_tag = gsGlobal->Per_Queue->pool_cur;
-	gsGlobal->Per_Queue->last_type = GIF_RESERVED;
-	gsGlobal->Per_Queue->mode = GS_PERSISTENT;
+	gsKit_queue_init(gsGlobal, gsGlobal->Per_Queue, GS_PERSISTENT, Per_AllocSize);
 
 	gsGlobal->CurQueue = gsGlobal->Os_Queue;
 
@@ -539,14 +523,11 @@ GSGLOBAL *gsKit_init_global_custom(int Os_AllocSize, int Per_AllocSize)
 
 void gsKit_deinit_global(GSGLOBAL *gsGlobal)
 {
-    gsGlobal->Per_Queue->pool[0] = (u64 *)((u32)gsGlobal->Per_Queue->pool[0] ^ 0x30000000);
-    gsGlobal->Os_Queue->pool[1] = (u64 *)((u32)gsGlobal->Os_Queue->pool[1] ^ 0x30000000);
-    gsGlobal->Os_Queue->pool[0] = (u64 *)((u32)gsGlobal->Os_Queue->pool[0] ^ 0x30000000);
+	gsKit_queue_free(gsGlobal, gsGlobal->Per_Queue);
+	gsKit_queue_free(gsGlobal, gsGlobal->Os_Queue);
+
     gsGlobal->dma_misc = (u64 *)((u32)gsGlobal->dma_misc ^ 0x30000000);
 
-    free(gsGlobal->Per_Queue->pool[0]);
-    free(gsGlobal->Os_Queue->pool[1]);
-    free(gsGlobal->Os_Queue->pool[0]);
     free(gsGlobal->dma_misc);
     free(gsGlobal->Per_Queue);
     free(gsGlobal->Os_Queue);

--- a/examples/font/font.c
+++ b/examples/font/font.c
@@ -44,6 +44,8 @@ int main(int argc, char *argv[])
 	WhiteTrans = GS_SETREG_RGBAQ(0xFF,0xFF,0xFF,0x50,0x00);
 
 	gsGlobal->PrimAlpha = GS_BLEND_FRONT2BACK;
+	gsGlobal->PSM = GS_PSM_CT16;
+	gsGlobal->PSMZ = GS_PSMZ_16;
 
 	gsKit_init_screen(gsGlobal);
 


### PR DESCRIPTION
This patch series has some small fixed and additions, most notably it adds:
- More control over draw queues. So an application can use custom queues while still being compatible with the builtin GS_ONESHOT and GS_PERSISTENT.
- hsync handler in the same way the vsync handler is implemented.

I'm having a some problems compiling and running OPL at the moment, so can someone test this with OPL?