### PR TITLE
Add half pixel offset rendering

### DIFF
--- a/ee/gs/src/gsFontM.c
+++ b/ee/gs/src/gsFontM.c
@@ -73,12 +73,7 @@ int gsKit_fontm_upload(GSGLOBAL *gsGlobal, GSFONTM *gsFontM)
     gsFontM->Texture->PSM = GS_PSM_T4;
     gsFontM->Texture->ClutPSM = GS_PSM_CT32;
     gsFontM->Texture->Filter = GS_FILTER_LINEAR;
-
-	gsFontM->Texture->TBW = (-GS_VRAM_TBWALIGN_CLUT)&(gsFontM->Texture->Width+GS_VRAM_TBWALIGN_CLUT-1);
-    if(gsFontM->Texture->TBW / 64 > 0)
-        gsFontM->Texture->TBW = (gsFontM->Texture->TBW / 64);
-    else
-		gsFontM->Texture->TBW = 1;
+    gsKit_setup_tbw(gsFontM->Texture);
 
 	gsFontM->Texture->VramClut = gsKit_vram_alloc(gsGlobal, 4096, GSKIT_ALLOC_USERBUFFER);
 	int TexSize = gsKit_texture_size(gsFontM->Texture->Width, gsFontM->Texture->Height, gsFontM->Texture->PSM);

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -182,6 +182,11 @@ void gsKit_set_buffer_attributes(GSGLOBAL *gsGlobal)
 	gsGlobal->StartX += (gsGlobal->DW - ((gsGlobal->MagH + 1) * gsGlobal->Width )) / 2;
 	gsGlobal->StartY += (gsGlobal->DH - ((gsGlobal->MagV + 1) * gsGlobal->Height)) / 2;
 
+	if (gsGlobal->Interlace == GS_INTERLACED) {
+		// Do not change odd/even start position in interlaced mode
+		gsGlobal->StartY &= ~1;
+	}
+
 	// Calculate the actual display width and height
 	gsGlobal->DW = (gsGlobal->MagH + 1) * gsGlobal->Width;
 	gsGlobal->DH = (gsGlobal->MagV + 1) * gsGlobal->Height;
@@ -195,6 +200,11 @@ void gsKit_set_display_offset(GSGLOBAL *gsGlobal, int x, int y)
 {
 	gsGlobal->StartXOffset = x;
 	gsGlobal->StartYOffset = y;
+
+	if (gsGlobal->Interlace == GS_INTERLACED) {
+		// Do not change odd/even start position in interlaced mode
+		gsGlobal->StartYOffset &= ~1;
+	}
 
 	GS_SET_DISPLAY1(
 			gsGlobal->StartX + gsGlobal->StartXOffset,	// X position in the display area (in VCK unit

--- a/examples/fb/fb.c
+++ b/examples/fb/fb.c
@@ -126,7 +126,7 @@ static void generate_frame(GSTEXTURE *tex)
 
 			pixels[y*stride + x] = color;
 		}
-           }
+	}
 }
 
 int main(int argc, char *argv[])
@@ -169,9 +169,12 @@ int main(int argc, char *argv[])
 
 	fb.Filter = GS_FILTER_LINEAR; /* enable bilinear filtering */
 
+	gsKit_setup_tbw(&fb);
+
 	generate_palette(&fb);
 
 #ifdef USEBMP
+	backtex.Delayed = 0;
 	gsKit_texture_bmp(gsGlobal, &backtex, "host:bsdgirl.bmp");
 #endif
 
@@ -238,11 +241,11 @@ int main(int argc, char *argv[])
 		/* upload new frame buffer */
 		gsKit_texture_upload(gsGlobal, &fb);
 
-        /* vsync and flip buffer */
-        gsKit_sync_flip(gsGlobal);
-
 		/* execute render queue */
 		gsKit_queue_exec(gsGlobal);
+
+		/* vsync and flip buffer */
+		gsKit_sync_flip(gsGlobal);
 	}
 
 	/* keep compilers happy (tm) */

--- a/examples/font/font.c
+++ b/examples/font/font.c
@@ -77,8 +77,8 @@ int main(int argc, char *argv[])
 							       "Testing 10\n");
 	while(1)
 	{
-		gsKit_sync_flip(gsGlobal);
 		gsKit_queue_exec(gsGlobal);
+		gsKit_sync_flip(gsGlobal);
 	}
 
 	return 0;

--- a/examples/fontm/fontm.c
+++ b/examples/fontm/fontm.c
@@ -75,7 +75,6 @@ int main(int argc, char *argv[])
 
 	while(1)
 	{
-
                 if( y <= 10  && (x + width) < (gsGlobal->Width - 10))
                         x+=5;
                 else if( (y + height)  <  (VHeight - 10) && (x + width) >= (gsGlobal->Width - 10) )
@@ -136,9 +135,8 @@ int main(int argc, char *argv[])
 		gsKit_prim_sprite(gsGlobal, x, y, x + width, y + height, 4, BlueTrans);
 		gsKit_prim_sprite(gsGlobal, x, y2, x + width, y2 + height, 3, GreenTrans);
 
-		gsKit_sync_flip(gsGlobal);
-
 		gsKit_queue_exec(gsGlobal);
+		gsKit_sync_flip(gsGlobal);
 	}
 
 	return 0;


### PR DESCRIPTION
This wil make a 1920x540 buffer look as sharp as 1920x1080 buffer, when unsing interlaced frame mode. The result is that only half the GS memory is now needed to get 1080i 3D look good. The rest is available for textures.