### PR TITLE
Bugfixes

### DIFF
--- a/ee/gs/src/gsCore.c
+++ b/ee/gs/src/gsCore.c
@@ -494,9 +494,9 @@ void gsKit_queue_reset(GSQUEUE *Queue)
 		if(Queue->mode == GS_ONESHOT)
 		{
 			Queue->dbuf  ^= 1;
-			Queue->dma_tag = Queue->pool[Queue->dbuf];
 		}
 
+		Queue->dma_tag = Queue->pool[Queue->dbuf];
 		Queue->pool_cur = Queue->dma_tag + 16;
 		Queue->last_type = GIF_RESERVED;
 		Queue->last_tag = Queue->pool_cur;

--- a/ee/gs/src/gsHires.c
+++ b/ee/gs/src/gsHires.c
@@ -279,11 +279,17 @@ static void dma_to_gs_thread(void * data)
 	while(1)
 	{
 		// Make sure the sema count == 0
-		PollSema(sema_hsync_id);
+		while (PollSema(sema_hsync_id) >= 0)
+			;
+
 		// Wait for CRTC
 		WaitSema(sema_hsync_id);
 
 		WaitSema(sema_queue_id);
+
+#ifdef BG_DEBUG
+		GS_SET_BGCOLOR(128,0,0);
+#endif
 
 		// Send current pass queue
 		if ((gsGlobal->Interlace == GS_INTERLACED) && (gsGlobal->Field == GS_FRAME)) {
@@ -300,6 +306,10 @@ static void dma_to_gs_thread(void * data)
 		iQueue = (iCurrentDrawQueue == 0) ? 1 : 0;
 		gsKit_queue_send(gsGlobal, &DrawQueue[iQueue]);
 
+#ifdef BG_DEBUG
+		GS_SET_BGCOLOR(0,128,0);
+#endif
+
 		SignalSema(sema_queue_id);
 
 		// If this was the last pass, send vsync
@@ -311,7 +321,8 @@ static void dma_to_gs_thread(void * data)
 void gsKit_hires_sync(GSGLOBAL *gsGlobal)
 {
 	// Make sure the sema count == 0
-	PollSema(sema_vsync_id);
+	while (PollSema(sema_vsync_id) >= 0)
+		;
 
 	// Wait for vsync
 	WaitSema(sema_vsync_id);


### PR DESCRIPTION
The 12 year old bug causes a memory leak for persistent queues when transferring textures. Most applications don't use persistent queues, and if they do they don't use it for transferring textures. Unfortunately hires mode only uses persistent queues and it made some hires applications crash after a while.

There was also a strange issue with semaphore polling. The semaphores used can be max 1, but somehow I need to poll the semaphore more than once to make it go 0.