### PR TITLE
 Check and clip input parameters

### DIFF
--- a/Makefile.global
+++ b/Makefile.global
@@ -12,21 +12,14 @@
 
 include $(GSKITSRC)/ee/Rules.make
 
-EE_LIBS = -Xlinker --start-group
-
-EE_LIBS += -lc -lkernel
-
 ifdef GSKIT_DEBUG
     EE_CFLAGS += -DGSKIT_DEBUG
     EE_INCS += -I$(PS2GDB)/ee
     EE_LIB_DIRS += -L$(PS2GDB)/lib
 endif
 
-EE_LIBS += -Xlinker --end-group
-
 # include dir
-EE_INCS += -I$(GSKITSRC)/ee/gs/include  -I$(GSKITSRC)/ee/dma/include
-EE_CFLAGS += -fno-builtin-printf
+EE_INCS += -I$(GSKITSRC)/ee/gs/include -I$(GSKITSRC)/ee/dma/include
 
 # linker flags
 EE_LIB_DIRS += -L$(PS2SDK)/ee/lib

--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -23,8 +23,7 @@ EE_CXXFLAGS := -D_EE -O2 -G0 -Wall $(EE_CXXFLAGS)
 #endif
 
 # Linker flags
-EE_LDFLAGS := -mno-crt0 $(EE_LDFLAGS)
-# EE_LDFLAGS := -nostartfiles $(EE_LDFLAGS)
+#EE_LDFLAGS := $(EE_LDFLAGS)
 
 # Assembler flags
 EE_ASFLAGS := -G0 $(EE_ASFLAGS)
@@ -36,16 +35,16 @@ EE_C_COMPILE = $(EE_CC) $(EE_CFLAGS) $(EE_INCS)
 EE_CXX_COMPILE = $(EE_CC) $(EE_CXXFLAGS) $(EE_INCS)
 
 
-$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.c
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.cpp
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.cpp
 	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.S
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.S
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.s
+$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.s
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 
 $(EE_LIB_DIR):
@@ -58,14 +57,12 @@ $(EE_OBJS_DIR):
 	mkdir $(EE_OBJS_DIR)
 
 ifeq ($(use_cpp), true)
-$(EE_BIN) : $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CXX) -T$(PS2SDK)/ee/startup/linkfile $(EE_LDFLAGS) \
-		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LIBS)
+$(EE_BIN): $(EE_OBJS)
+	$(EE_CXX) $(EE_LDFLAGS) -o $(EE_BIN) $(EE_OBJS) $(EE_LIBS)
 else
-$(EE_BIN) : $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
-	$(EE_CC) -T$(PS2SDK)/ee/startup/linkfile $(EE_LDFLAGS) \
-		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LIBS)
+$(EE_BIN): $(EE_OBJS)
+	$(EE_CC) $(EE_LDFLAGS) -o $(EE_BIN) $(EE_OBJS) $(EE_LIBS)
 endif
 
-$(EE_LIB) : $(EE_OBJS)
+$(EE_LIB): $(EE_OBJS)
 	$(EE_AR) cru $(EE_LIB) $(EE_OBJS)

--- a/ee/dma/src/Makefile
+++ b/ee/dma/src/Makefile
@@ -13,7 +13,7 @@ EE_OBJS = 	dmaCore.o \
 		dmaInit.o \
 		dmaSpr.o
 
-EE_CFLAGS += -Wno-unused -O2
+EE_CFLAGS += -Wno-unused
 
 all: $(EE_OBJS)
 	$(EE_AR) rcs $(LIBDMAKIT) $(EE_OBJS)

--- a/ee/gs/include/gsInline.h
+++ b/ee/gs/include/gsInline.h
@@ -86,4 +86,59 @@ static inline void *gsKit_heap_alloc_dma(GSGLOBAL *gsGlobal, int qsize, int bsiz
 	return p_heap;
 }
 
+static inline int __gsKit_float_to_int_uv(float fuv, int imax)
+{
+	int iuv = (int)(fuv * 16.0f);
+
+	// Limit u/v to texture width/height
+
+	if (iuv < 0)
+		iuv = 0;
+
+	if (iuv > imax)
+		iuv = imax;
+
+	// Prevent overflow when using maximum size texture
+
+	if (iuv >= (1024 * 16))
+		iuv = (1024 * 16) - 1;
+
+	return iuv;
+}
+
+static inline int gsKit_float_to_int_u(const GSTEXTURE *Texture, float fu)
+{
+	return __gsKit_float_to_int_uv(fu, Texture->Width * 16);
+}
+
+static inline int gsKit_float_to_int_v(const GSTEXTURE *Texture, float fv)
+{
+	return __gsKit_float_to_int_uv(fv, Texture->Height * 16);
+}
+
+static inline int __gsKit_float_to_int_xy(float fxy, int offset)
+{
+	int ixy = (int)(fxy * 16.0f) + offset;
+
+	// Limit x/y to Primitive Coordinate System (0 to 4095.9375)
+
+	if (ixy < 0)
+		ixy = 0;
+
+	if (ixy >= (4096 * 16))
+		ixy = (4096 * 16) - 1;
+
+	return ixy;
+}
+
+static inline int gsKit_float_to_int_x(const GSGLOBAL *gsGlobal, float fx)
+{
+	return __gsKit_float_to_int_xy(fx, gsGlobal->OffsetX);
+}
+
+static inline int gsKit_float_to_int_y(const GSGLOBAL *gsGlobal, float fy)
+{
+	return __gsKit_float_to_int_xy(fy, gsGlobal->OffsetY);
+}
+
 #endif /* __GSINLINE_H__ */

--- a/ee/gs/src/Makefile
+++ b/ee/gs/src/Makefile
@@ -19,7 +19,7 @@ EE_OBJS = 	gsCore.o \
 		gsTexture.o \
 		gsVU1.o
 
-EE_CFLAGS += -Wno-unused -O2
+EE_CFLAGS += -Wno-unused
 
 all: $(EE_OBJS)
 	$(EE_AR) rcs $(LIBGSKIT) $(EE_OBJS)

--- a/ee/gs/src/gsPrimitive.c
+++ b/ee/gs/src/gsPrimitive.c
@@ -21,8 +21,8 @@ void gsKit_prim_point(GSGLOBAL *gsGlobal, float x, float y, int iz, u64 color)
 	int qsize = 2;
 	int bsize = 32;
 
-	int ix = (int)(x * 16.0f) + gsGlobal->OffsetX;
-	int iy = (int)(y * 16.0f) + gsGlobal->OffsetY;
+	int ix = gsKit_float_to_int_x(gsGlobal, x);
+	int iy = gsKit_float_to_int_y(gsGlobal, y);
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, bsize, GIF_PRIM_POINT);
 
@@ -38,7 +38,6 @@ void gsKit_prim_point(GSGLOBAL *gsGlobal, float x, float y, int iz, u64 color)
 
 	*p_data++ = color;
 	*p_data++ = GS_SETREG_XYZ2( ix, iy, iz );
-
 }
 
 void gsKit_prim_line_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1, float x2, float y2, int iz2, u64 color)
@@ -48,12 +47,11 @@ void gsKit_prim_line_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1, float x
 	int qsize = 2;
 	int bsize = 32;
 
-	int ix1 = (int)(x1 * 16.0f) + gsGlobal->OffsetX;
-	int iy1 = (int)(y1 * 16.0f) + gsGlobal->OffsetY;
+	int ix1 = gsKit_float_to_int_x(gsGlobal, x1);
+	int iy1 = gsKit_float_to_int_y(gsGlobal, y1);
 
-	int ix2 = (int)(x2 * 16.0f) + gsGlobal->OffsetX;
-	int iy2 = (int)(y2 * 16.0f) + gsGlobal->OffsetY;
-
+	int ix2 = gsKit_float_to_int_x(gsGlobal, x2);
+	int iy2 = gsKit_float_to_int_y(gsGlobal, y2);
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, bsize, GIF_PRIM_LINE);
 
@@ -79,12 +77,11 @@ void gsKit_prim_line_goraud_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1, 
 	int qsize = 3;
 	int bsize = 48;
 
-	int ix1 = (int)(x1 * 16.0f) + gsGlobal->OffsetX;
-	int iy1 = (int)(y1 * 16.0f) + gsGlobal->OffsetY;
+	int ix1 = gsKit_float_to_int_x(gsGlobal, x1);
+	int iy1 = gsKit_float_to_int_y(gsGlobal, y1);
 
-	int ix2 = (int)(x2 * 16.0f) + gsGlobal->OffsetX;
-	int iy2 = (int)(y2 * 16.0f) + gsGlobal->OffsetY;
-
+	int ix2 = gsKit_float_to_int_x(gsGlobal, x2);
+	int iy2 = gsKit_float_to_int_y(gsGlobal, y2);
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, bsize, GIF_PRIM_LINE);
 
@@ -115,8 +112,8 @@ void gsKit_prim_line_strip(GSGLOBAL *gsGlobal, float *LineStrip, int segments, i
 
 	for(count = 0; count < (segments * 2); count+=2)
 	{
-		vertexdata[count] = (int)((*LineStrip++) * 16.0f) + gsGlobal->OffsetX;
-		vertexdata[count+1] = (int)((*LineStrip++) * 16.0f) + gsGlobal->OffsetY;
+		vertexdata[count+0] = gsKit_float_to_int_x(gsGlobal, *LineStrip++);
+		vertexdata[count+1] = gsKit_float_to_int_y(gsGlobal, *LineStrip++);
 	}
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize * 16), GIF_AD);
@@ -137,7 +134,6 @@ void gsKit_prim_line_strip(GSGLOBAL *gsGlobal, float *LineStrip, int segments, i
 		*p_data++ = GS_SETREG_XYZ2( vertexdata[count], vertexdata[count+1], iz );
 		*p_data++ = GS_XYZ2;
 	}
-
 }
 
 void gsKit_prim_line_strip_3d(GSGLOBAL *gsGlobal, float *LineStrip, int segments, u64 color)
@@ -150,9 +146,9 @@ void gsKit_prim_line_strip_3d(GSGLOBAL *gsGlobal, float *LineStrip, int segments
 
 	for(count = 0; count < (segments * 3); count+=3)
 	{
-		vertexdata[count] = (int)((*LineStrip++) * 16.0f) + gsGlobal->OffsetX;
-		vertexdata[count+1] = (int)((*LineStrip++) * 16.0f) + gsGlobal->OffsetY;
-		vertexdata[count+2] = (int)((*LineStrip++) * 16.0f);
+		vertexdata[count+0] = gsKit_float_to_int_x(gsGlobal, *LineStrip++);
+		vertexdata[count+1] = gsKit_float_to_int_y(gsGlobal, *LineStrip++);
+		vertexdata[count+2] = (int)((*LineStrip++) * 16.0f); // z
 	}
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize * 16), GIF_AD);
@@ -174,7 +170,6 @@ void gsKit_prim_line_strip_3d(GSGLOBAL *gsGlobal, float *LineStrip, int segments
 		*p_data++ = GS_SETREG_XYZ2( vertexdata[count], vertexdata[count+1], vertexdata[count+2] );
 		*p_data++ = GS_XYZ2;
 	}
-
 }
 
 void gsKit_prim_sprite(GSGLOBAL *gsGlobal, float x1, float y1, float x2, float y2, int iz, u64 color)
@@ -184,10 +179,11 @@ void gsKit_prim_sprite(GSGLOBAL *gsGlobal, float x1, float y1, float x2, float y
 	int qsize = 2;
 	int bsize = 32;
 
-	int ix1 = (int)(x1 * 16.0f) + gsGlobal->OffsetX;
-	int ix2 = (int)(x2 * 16.0f) + gsGlobal->OffsetX;
-	int iy1 = (int)(y1 * 16.0f) + gsGlobal->OffsetY;
-	int iy2 = (int)(y2 * 16.0f) + gsGlobal->OffsetY;
+	int ix1 = gsKit_float_to_int_x(gsGlobal, x1);
+	int iy1 = gsKit_float_to_int_y(gsGlobal, y1);
+
+	int ix2 = gsKit_float_to_int_x(gsGlobal, x2);
+	int iy2 = gsKit_float_to_int_y(gsGlobal, y2);
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, bsize, GIF_PRIM_SPRITE);
 
@@ -204,7 +200,6 @@ void gsKit_prim_sprite(GSGLOBAL *gsGlobal, float x1, float y1, float x2, float y
 	*p_data++ = color;
 	*p_data++ = GS_SETREG_XYZ2( ix1, iy1, iz );
 	*p_data++ = GS_SETREG_XYZ2( ix2, iy2, iz );
-
 }
 
 void gsKit_prim_triangle_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1,
@@ -216,14 +211,14 @@ void gsKit_prim_triangle_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1,
 	int qsize = 3;
 	int bsize = 48;
 
-	int ix1 = (int)(x1 * 16.0f) + gsGlobal->OffsetX;
-	int iy1 = (int)(y1 * 16.0f) + gsGlobal->OffsetY;
+	int ix1 = gsKit_float_to_int_x(gsGlobal, x1);
+	int iy1 = gsKit_float_to_int_y(gsGlobal, y1);
 
-	int ix2 = (int)(x2 * 16.0f) + gsGlobal->OffsetX;
-	int iy2 = (int)(y2 * 16.0f) + gsGlobal->OffsetY;
+	int ix2 = gsKit_float_to_int_x(gsGlobal, x2);
+	int iy2 = gsKit_float_to_int_y(gsGlobal, y2);
 
-	int ix3 = (int)(x3 * 16.0f) + gsGlobal->OffsetX;
-	int iy3 = (int)(y3 * 16.0f) + gsGlobal->OffsetY;
+	int ix3 = gsKit_float_to_int_x(gsGlobal, x3);
+	int iy3 = gsKit_float_to_int_y(gsGlobal, y3);
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, bsize, GIF_PRIM_TRIANGLE);
 
@@ -238,7 +233,6 @@ void gsKit_prim_triangle_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1,
 	*p_data++ = GS_SETREG_XYZ2( ix1, iy1, iz1 );
 	*p_data++ = GS_SETREG_XYZ2( ix2, iy2, iz2 );
 	*p_data++ = GS_SETREG_XYZ2( ix3, iy3, iz3 );
-
 }
 
 void gsKit_prim_triangle_strip(GSGLOBAL *gsGlobal, float *TriStrip, int segments, int iz, u64 color)
@@ -251,8 +245,8 @@ void gsKit_prim_triangle_strip(GSGLOBAL *gsGlobal, float *TriStrip, int segments
 
 	for(count = 0; count < (segments * 2); count+=2)
 	{
-		vertexdata[count] = (int)((*TriStrip++) * 16.0f) + gsGlobal->OffsetX;
-		vertexdata[count+1] = (int)((*TriStrip++) * 16.0f) + gsGlobal->OffsetY;
+		vertexdata[count+0] = gsKit_float_to_int_x(gsGlobal, *TriStrip++);
+		vertexdata[count+1] = gsKit_float_to_int_y(gsGlobal, *TriStrip++);
 	}
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize * 16), GIF_AD);
@@ -274,7 +268,6 @@ void gsKit_prim_triangle_strip(GSGLOBAL *gsGlobal, float *TriStrip, int segments
 		*p_data++ = GS_SETREG_XYZ2( vertexdata[count], vertexdata[count+1], iz );
 		*p_data++ = GS_XYZ2;
 	}
-
 }
 
 void gsKit_prim_triangle_strip_3d(GSGLOBAL *gsGlobal, float *TriStrip, int segments, u64 color)
@@ -287,9 +280,9 @@ void gsKit_prim_triangle_strip_3d(GSGLOBAL *gsGlobal, float *TriStrip, int segme
 
 	for(count = 0; count < (segments * 3); count+=3)
 	{
-		vertexdata[count] = (int)((*TriStrip++) * 16.0f) + gsGlobal->OffsetX;
-		vertexdata[count+1] = (int)((*TriStrip++) * 16.0f) + gsGlobal->OffsetY;
-		vertexdata[count+2] = (int)((*TriStrip++) * 16.0f);
+		vertexdata[count+0] = gsKit_float_to_int_x(gsGlobal, *TriStrip++);
+		vertexdata[count+1] = gsKit_float_to_int_y(gsGlobal, *TriStrip++);
+		vertexdata[count+2] = (int)((*TriStrip++) * 16.0f); // z
 	}
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize * 16), GIF_AD);
@@ -311,7 +304,6 @@ void gsKit_prim_triangle_strip_3d(GSGLOBAL *gsGlobal, float *TriStrip, int segme
 		*p_data++ = GS_SETREG_XYZ2( vertexdata[count], vertexdata[count+1], vertexdata[count+2] );
 		*p_data++ = GS_XYZ2;
 	}
-
 }
 
 void gsKit_prim_triangle_fan(GSGLOBAL *gsGlobal, float *TriFan, int verticies, int iz, u64 color)
@@ -324,8 +316,8 @@ void gsKit_prim_triangle_fan(GSGLOBAL *gsGlobal, float *TriFan, int verticies, i
 
 	for(count = 0; count < (verticies * 2); count+=2)
 	{
-		vertexdata[count] = (int)((*TriFan++) * 16.0f) + gsGlobal->OffsetX;
-		vertexdata[count+1] = (int)((*TriFan++) * 16.0f) + gsGlobal->OffsetY;
+		vertexdata[count+0] = gsKit_float_to_int_x(gsGlobal, *TriFan++);
+		vertexdata[count+1] = gsKit_float_to_int_y(gsGlobal, *TriFan++);
 	}
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize * 16), GIF_AD);
@@ -347,7 +339,6 @@ void gsKit_prim_triangle_fan(GSGLOBAL *gsGlobal, float *TriFan, int verticies, i
 		*p_data++ = GS_SETREG_XYZ2( vertexdata[count], vertexdata[count+1], iz );
 		*p_data++ = GS_XYZ2;
 	}
-
 }
 
 void gsKit_prim_triangle_fan_3d(GSGLOBAL *gsGlobal, float *TriFan, int verticies, u64 color)
@@ -360,9 +351,9 @@ void gsKit_prim_triangle_fan_3d(GSGLOBAL *gsGlobal, float *TriFan, int verticies
 
 	for(count = 0; count < (verticies * 3); count+=3)
 	{
-		vertexdata[count] = (int)((*TriFan++) * 16.0f) + gsGlobal->OffsetX;
-		vertexdata[count+1] = (int)((*TriFan++) * 16.0f) + gsGlobal->OffsetY;
-		vertexdata[count+2] = (int)(*TriFan++ * 16.0f);
+		vertexdata[count+0] = gsKit_float_to_int_x(gsGlobal, *TriFan++);
+		vertexdata[count+1] = gsKit_float_to_int_y(gsGlobal, *TriFan++);
+		vertexdata[count+2] = (int)(*TriFan++ * 16.0f); // z
 	}
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize * 16), GIF_AD);
@@ -384,7 +375,6 @@ void gsKit_prim_triangle_fan_3d(GSGLOBAL *gsGlobal, float *TriFan, int verticies
 		*p_data++ = GS_SETREG_XYZ2( vertexdata[count], vertexdata[count+1], vertexdata[count+2] );
 		*p_data++ = GS_XYZ2;
 	}
-
 }
 
 
@@ -398,14 +388,14 @@ void gsKit_prim_triangle_gouraud_3d(GSGLOBAL *gsGlobal, float x1, float y1, int 
 	int qsize = 4;
 	int bsize = 64;
 
-	int ix1 = (int)(x1 * 16.0f) + gsGlobal->OffsetX;
-	int iy1 = (int)(y1 * 16.0f) + gsGlobal->OffsetY;
+	int ix1 = gsKit_float_to_int_x(gsGlobal, x1);
+	int iy1 = gsKit_float_to_int_y(gsGlobal, y1);
 
-	int ix2 = (int)(x2 * 16.0f) + gsGlobal->OffsetX;
-	int iy2 = (int)(y2 * 16.0f) + gsGlobal->OffsetY;
+	int ix2 = gsKit_float_to_int_x(gsGlobal, x2);
+	int iy2 = gsKit_float_to_int_y(gsGlobal, y2);
 
-	int ix3 = (int)(x3 * 16.0f) + gsGlobal->OffsetX;
-	int iy3 = (int)(y3 * 16.0f) + gsGlobal->OffsetY;
+	int ix3 = gsKit_float_to_int_x(gsGlobal, x3);
+	int iy3 = gsKit_float_to_int_y(gsGlobal, y3);
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, bsize, GIF_PRIM_TRIANGLE_GOURAUD);
 
@@ -439,17 +429,17 @@ void gsKit_prim_quad_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1,
 	int qsize = 3;
 	int bsize = 48;
 
-	int ix1 = (int)(x1 * 16.0f) + gsGlobal->OffsetX;
-	int iy1 = (int)(y1 * 16.0f) + gsGlobal->OffsetY;
+	int ix1 = gsKit_float_to_int_x(gsGlobal, x1);
+	int iy1 = gsKit_float_to_int_y(gsGlobal, y1);
 
-	int ix2 = (int)(x2 * 16.0f) + gsGlobal->OffsetX;
-	int iy2 = (int)(y2 * 16.0f) + gsGlobal->OffsetY;
+	int ix2 = gsKit_float_to_int_x(gsGlobal, x2);
+	int iy2 = gsKit_float_to_int_y(gsGlobal, y2);
 
-	int ix3 = (int)(x3 * 16.0f) + gsGlobal->OffsetX;
-	int iy3 = (int)(y3 * 16.0f) + gsGlobal->OffsetY;
+	int ix3 = gsKit_float_to_int_x(gsGlobal, x3);
+	int iy3 = gsKit_float_to_int_y(gsGlobal, y3);
 
-	int ix4 = (int)(x4 * 16.0f) + gsGlobal->OffsetX;
-	int iy4 = (int)(y4 * 16.0f) + gsGlobal->OffsetY;
+	int ix4 = gsKit_float_to_int_x(gsGlobal, x4);
+	int iy4 = gsKit_float_to_int_y(gsGlobal, y4);
 
 	p_store = p_data = gsKit_heap_alloc( gsGlobal, qsize, bsize, GIF_PRIM_QUAD);
 
@@ -468,7 +458,6 @@ void gsKit_prim_quad_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1,
 	*p_data++ = GS_SETREG_XYZ2( ix2, iy2, iz2 );
 	*p_data++ = GS_SETREG_XYZ2( ix3, iy3, iz3 );
 	*p_data++ = GS_SETREG_XYZ2( ix4, iy4, iz4 );
-
 }
 
 
@@ -484,17 +473,17 @@ void gsKit_prim_quad_gouraud_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1,
 	int qsize = 5;
 	int bsize = 80;
 
-	int ix1 = (int)(x1 * 16.0f) + gsGlobal->OffsetX;
-	int iy1 = (int)(y1 * 16.0f) + gsGlobal->OffsetY;
+	int ix1 = gsKit_float_to_int_x(gsGlobal, x1);
+	int iy1 = gsKit_float_to_int_y(gsGlobal, y1);
 
-	int ix2 = (int)(x2 * 16.0f) + gsGlobal->OffsetX;
-	int iy2 = (int)(y2 * 16.0f) + gsGlobal->OffsetY;
+	int ix2 = gsKit_float_to_int_x(gsGlobal, x2);
+	int iy2 = gsKit_float_to_int_y(gsGlobal, y2);
 
-	int ix3 = (int)(x3 * 16.0f) + gsGlobal->OffsetX;
-	int iy3 = (int)(y3 * 16.0f) + gsGlobal->OffsetY;
+	int ix3 = gsKit_float_to_int_x(gsGlobal, x3);
+	int iy3 = gsKit_float_to_int_y(gsGlobal, y3);
 
-	int ix4 = (int)(x4 * 16.0f) + gsGlobal->OffsetX;
-	int iy4 = (int)(y4 * 16.0f) + gsGlobal->OffsetY;
+	int ix4 = gsKit_float_to_int_x(gsGlobal, x4);
+	int iy4 = gsKit_float_to_int_y(gsGlobal, y4);
 
 	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, bsize, GIF_PRIM_QUAD_GOURAUD);
 
@@ -519,6 +508,5 @@ void gsKit_prim_quad_gouraud_3d(GSGLOBAL *gsGlobal, float x1, float y1, int iz1,
 
 	*p_data++ = color4;
 	*p_data++ = GS_SETREG_XYZ2( ix4, iy4, iz4 );
-
 }
 

--- a/ee/toolkit/Makefile.global
+++ b/ee/toolkit/Makefile.global
@@ -11,8 +11,6 @@
 
 include $(GSKITSRC)/ee/Rules.make
 
-EE_LIBS = -Xlinker --start-group
-
 ifdef LIBJPEG
     EE_INCS += -I$(LIBJPEG)/include
     EE_CFLAGS += -DHAVE_LIBJPEG
@@ -43,13 +41,9 @@ ifdef GSKIT_DEBUG
 endif
 
 EE_LIBS += -lgskit -ldmakit
-EE_LIBS += -lc -lkernel
-
-EE_LIBS += -Xlinker --end-group
 
 # include dir
 EE_INCS += -I$(GSKITSRC)/ee/gs/include -I$(GSKITSRC)/ee/dma/include
-EE_CFLAGS += -fno-builtin-printf
 EE_INCS += -I$(GSKITSRC)/ee/toolkit/include
 
 # linker flags

--- a/ee/toolkit/src/Makefile
+++ b/ee/toolkit/src/Makefile
@@ -11,8 +11,6 @@
 
 EE_OBJS = gsToolkit.o
 
-EE_CFLAGS += -O2
-
 all: $(EE_OBJS)
 	$(EE_AR) rcs $(LIBGSKIT_TOOLKIT) $(EE_OBJS)
 

--- a/examples/Makefile.global
+++ b/examples/Makefile.global
@@ -11,8 +11,6 @@
 
 include $(GSKITSRC)/ee/Rules.make
 
-EE_LIBS = -Xlinker --start-group $(EE_LIBS_EXTRA)
-
 ifdef LIBJPEG
 	EE_INCS += -I$(LIBJPEG)/include
 	EE_CFLAGS += -DHAVE_LIBJPEG
@@ -38,16 +36,25 @@ endif
 
 EE_LIBS += -lgskit_toolkit
 EE_LIBS += -lgskit -ldmakit
-EE_LIBS += -lc -lkernel
-
-EE_LIBS += -Xlinker --end-group
 
 # include dir
 EE_INCS += -I$(GSKITSRC)/ee/gs/include -I$(GSKITSRC)/ee/dma/include
-EE_CFLAGS += -fno-builtin-printf
 EE_INCS += -I$(GSKITSRC)/ee/toolkit/include
 
 # linker flags
 EE_LIB_DIRS += -L$(GSKITSRC)/lib
 EE_LIB_DIRS += -L$(PS2SDK)/ee/lib
 EE_LDFLAGS += $(EE_LIB_DIRS)
+
+all: $(EE_BIN)
+
+test: all
+	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
+
+reset: clean
+	ps2client -h $(PS2_IP) reset
+
+clean:
+	rm -f $(EE_OBJS) $(EE_BIN)
+
+install: all

--- a/examples/alpha/Makefile
+++ b/examples/alpha/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = alpha.elf
 EE_OBJS = alpha.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/basic/Makefile
+++ b/examples/basic/Makefile
@@ -11,20 +11,6 @@
 
 EE_BIN  = basic.elf
 EE_OBJS = basic.o
-EE_CFLAGS += -g
-
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
 
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/bigtex/Makefile
+++ b/examples/bigtex/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = bigtex.elf
 EE_OBJS = bigtex.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/coverflow/Makefile
+++ b/examples/coverflow/Makefile
@@ -13,18 +13,5 @@
 EE_BIN  = coverflow.elf
 EE_OBJS = coverflow.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/fb/Makefile
+++ b/examples/fb/Makefile
@@ -11,20 +11,6 @@
 
 EE_BIN  = fb.elf
 EE_OBJS = fb.o
-EE_LIBS = -lm
-
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
 
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/font/Makefile
+++ b/examples/font/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = font.elf
 EE_OBJS = font.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/fontm/Makefile
+++ b/examples/fontm/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = fontm.elf
 EE_OBJS = fontm.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/hires/Makefile
+++ b/examples/hires/Makefile
@@ -11,20 +11,7 @@
 
 EE_BIN  = hires.elf
 EE_OBJS = main.o
-EE_LIBS_EXTRA = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
-
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
+EE_LIBS = -ldraw -lgraph -lmath3d -lmf -lpacket -ldma
 
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/linuz-texture/Makefile
+++ b/examples/linuz-texture/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = texture.elf
 EE_OBJS = texture.o testorig.o sample.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/modetest/Makefile
+++ b/examples/modetest/Makefile
@@ -11,20 +11,7 @@
 
 EE_BIN  = modetest.elf
 EE_OBJS = modetest.o pad.o
-EE_LIBS_EXTRA = -lpad
-
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
+EE_LIBS = -lpad
 
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/pixelperfect/Makefile
+++ b/examples/pixelperfect/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = pixelperfect.elf
 EE_OBJS = pixelperfect.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/png-texture/Makefile
+++ b/examples/png-texture/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = textures.elf
 EE_OBJS = textures.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/texstream/Makefile
+++ b/examples/texstream/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = texstream.elf
 EE_OBJS = texstream.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/textures/Makefile
+++ b/examples/textures/Makefile
@@ -12,18 +12,5 @@
 EE_BIN  = textures.elf
 EE_OBJS = textures.o
 
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
-
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/vsync/Makefile
+++ b/examples/vsync/Makefile
@@ -11,20 +11,6 @@
 
 EE_BIN  = vsync.elf
 EE_OBJS = vsync.o
-EE_CFLAGS += -g
-
-all: $(EE_BIN)
-
-test: all
-	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
-
-reset: clean
-	ps2client -h $(PS2_IP) reset
-
-clean:
-	rm -f $(EE_OBJS) $(EE_BIN)
-
-install: all
 
 include ../../Makefile.pref
 include ../Makefile.global


### PR DESCRIPTION
gsKit uses mostly floating point values for x,y,u and v in the interface and then converts these values to ps2 integers. This pull request adds clipping, so the x,y,u and v values will not overflow.

This fixes:
- 1024 width/height texture problem
- 1080i left/right animation in OPL

I also cleaned up some makefile constructions that where no longer used/required.