### PR TITLE
GSKIT some fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ before_script:
 script:
   # It is difficult to export variables into Docker image, so I use setup.sh for this
 #  - docker exec -t $(cat container_id) bash -c "export LIBJPEG=$PS2SDK/ports && export LIBPNG=$PS2SDK/ports && export ZLIB=$PS2SDK/ports && export LIBTIFF=$PS2SDK/ports && cd /gsKit/ && make"
-  - docker exec -t $(cat container_id) bash -c "cd /gsKit/; ./setup.sh && make"
+  - docker exec -t $(cat container_id) bash -c "cd /gsKit/; ./setup.sh && make GSKIT_DEBUG=1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: cpp
+
+services:
+  - docker
+
+sudo: required
+
+env:
+  - MATRIX_EVAL="PS2DOCKER=akuhak/ps2toolchain PS2FORK=ps2dev PS2BRANCH=master"
+  - MATRIX_EVAL="PS2DOCKER=ps2homebrew/ps2toolchain PS2FORK=uyjulian PS2BRANCH=uyjworking"
+
+matrix:
+  allow_failures:
+    - env:
+        - MATRIX_EVAL="PS2DOCKER=ps2homebrew/ps2toolchain PS2FORK=uyjulian PS2BRANCH=uyjworking"
+
+before_install:
+    - eval "${MATRIX_EVAL}"
+
+before_script:
+  # Get docker image
+  - docker pull ${PS2DOCKER}:latest
+  - docker ps
+
+  # Run DOCKER, run!
+  - docker run -d ${PS2DOCKER} bash -c "while true; do sleep 5; done" > container_id
+
+  # Configure ps2sdk
+  - docker exec -t $(cat container_id) bash -c "ls -l"
+  - docker exec -t $(cat container_id) bash -c "cd /; git clone https://github.com/${PS2FORK}/ps2sdk -b ${PS2BRANCH}"
+  - docker exec -t $(cat container_id) bash -c "cd /ps2sdk/; make install --silent"
+
+  # installing ports
+  - docker exec -t $(cat container_id) bash -c "cd /; git clone https://github.com/ps2dev/ps2sdk-ports; cd /ps2sdk-ports/; make libtiff libpng libjpeg freetype2"
+
+  - docker exec -t $(cat container_id) bash -c "mkdir -p /gsKit/;"
+  - docker cp $TRAVIS_BUILD_DIR/. $(cat container_id):/gsKit/
+
+script:
+  # It is difficult to export variables into Docker image, so I use setup.sh for this
+#  - docker exec -t $(cat container_id) bash -c "export LIBJPEG=$PS2SDK/ports && export LIBPNG=$PS2SDK/ports && export ZLIB=$PS2SDK/ports && export LIBTIFF=$PS2SDK/ports && cd /gsKit/ && make"
+  - docker exec -t $(cat container_id) bash -c "cd /gsKit/; ./setup.sh && make"

--- a/ee/Rules.make
+++ b/ee/Rules.make
@@ -2,25 +2,27 @@
 #  ____|   |    ____|   |        | |____|
 # |     ___|   |____ ___|    ____| |    \    PS2DEV Open Source Project.
 #-----------------------------------------------------------------------
-# Copyright 2001-2004.
+# Copyright 2001-2004, ps2dev - http://www.ps2dev.org
 # Licenced under Academic Free License version 2.0
 # Review ps2sdk README & LICENSE files for further details.
+
+EE_CC_VERSION != $(EE_CC) -dumpversion 2>&1
 
 EE_INCS := $(EE_INCS) -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -I$(GSKIT)/ee/dma/include -I$(GSKIT)/ee/gs/include
 
 # C compiler flags
 EE_CFLAGS := -D_EE -O2 -G0 -Wall $(EE_CFLAGS)
 
-#ifdef GSKIT_DEBUG
-#	EE_CFLAGS += -DGSKIT_DEBUG
-#endif
+ifdef GSKIT_DEBUG
+	EE_CFLAGS += -DGSKIT_DEBUG
+endif
 
 # C++ compiler flags
 EE_CXXFLAGS := -D_EE -O2 -G0 -Wall $(EE_CXXFLAGS)
 
-#ifdef GSKIT_DEBUG
-#	EE_CXXFLAGS += -DGSKIT_DEBUG
-#endif
+ifdef GSKIT_DEBUG
+	EE_CXXFLAGS += -DGSKIT_DEBUG
+endif
 
 # Linker flags
 #EE_LDFLAGS := $(EE_LDFLAGS)
@@ -32,37 +34,48 @@ EE_ASFLAGS := -G0 $(EE_ASFLAGS)
 
 # These macros can be used to simplify certain build rules.
 EE_C_COMPILE = $(EE_CC) $(EE_CFLAGS) $(EE_INCS)
-EE_CXX_COMPILE = $(EE_CC) $(EE_CXXFLAGS) $(EE_INCS)
+EE_CXX_COMPILE = $(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS)
 
+# Extra macro for disabling the automatic inclusion of the built-in CRT object(s)
+ifeq ($(EE_CC_VERSION),3.2.2)
+	EE_NO_CRT = -mno-crt0
+else ifeq ($(EE_CC_VERSION),3.2.3)
+	EE_NO_CRT = -mno-crt0
+else
+	EE_NO_CRT = -nostartfiles
+endif
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.c
+$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.c
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.cpp
+$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.cpp
 	$(EE_CXX) $(EE_CXXFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.S
+$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.S
 	$(EE_CC) $(EE_CFLAGS) $(EE_INCS) -c $< -o $@
 
-$(EE_OBJS_DIR)%.o: $(EE_SRC_DIR)%.s
+$(EE_OBJS_DIR)%.o : $(EE_SRC_DIR)%.s
 	$(EE_AS) $(EE_ASFLAGS) $< -o $@
 
 $(EE_LIB_DIR):
-	mkdir $(EE_LIB_DIR)
+	mkdir -p $(EE_LIB_DIR)
 
 $(EE_BIN_DIR):
-	mkdir $(EE_BIN_DIR)
+	mkdir -p $(EE_BIN_DIR)
 
 $(EE_OBJS_DIR):
-	mkdir $(EE_OBJS_DIR)
+	mkdir -p $(EE_OBJS_DIR)
 
 ifeq ($(use_cpp), true)
-$(EE_BIN): $(EE_OBJS)
-	$(EE_CXX) $(EE_LDFLAGS) -o $(EE_BIN) $(EE_OBJS) $(EE_LIBS)
+$(EE_BIN) : $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
+	$(EE_CXX) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CFLAGS) \
+		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
 else
-$(EE_BIN): $(EE_OBJS)
-	$(EE_CC) $(EE_LDFLAGS) -o $(EE_BIN) $(EE_OBJS) $(EE_LIBS)
+$(EE_BIN) : $(EE_OBJS) $(PS2SDK)/ee/startup/crt0.o
+	$(EE_CC) $(EE_NO_CRT) -T$(PS2SDK)/ee/startup/linkfile $(EE_CFLAGS) \
+		-o $(EE_BIN) $(PS2SDK)/ee/startup/crt0.o $(EE_OBJS) $(EE_LDFLAGS) $(EE_LIBS)
 endif
+
 
 $(EE_LIB): $(EE_OBJS)
 	$(EE_AR) cru $(EE_LIB) $(EE_OBJS)

--- a/ee/gs/include/gsInline.h
+++ b/ee/gs/include/gsInline.h
@@ -31,7 +31,7 @@ static inline void *gsKit_heap_alloc(GSGLOBAL *gsGlobal, int qsize, int bsize, i
 		*(u64 *)gsGlobal->CurQueue->dma_tag = DMA_TAG(gsGlobal->CurQueue->tag_size, 0, DMA_CNT, 0, 0, 0);
 		gsGlobal->CurQueue->tag_size = 0;
 		gsGlobal->CurQueue->dma_tag = gsGlobal->CurQueue->pool_cur;
-		(u8*)gsGlobal->CurQueue->pool_cur += 16;
+		gsGlobal->CurQueue->pool_cur = (void*)((u8*)gsGlobal->CurQueue->pool_cur + 16);
 	}
 
 	if(type == GIF_AD || type != gsGlobal->CurQueue->last_type || gsGlobal->CurQueue->same_obj >= GS_GIF_BLOCKSIZE)
@@ -51,7 +51,7 @@ static inline void *gsKit_heap_alloc(GSGLOBAL *gsGlobal, int qsize, int bsize, i
 	gsGlobal->CurQueue->last_type = type;
 	gsGlobal->CurQueue->tag_size += qsize;
 	void *p_heap = gsGlobal->CurQueue->pool_cur;
-	(u8*)gsGlobal->CurQueue->pool_cur += bsize;
+	gsGlobal->CurQueue->pool_cur = (void*)((u8*)gsGlobal->CurQueue->pool_cur + bsize);
 
 	return p_heap;
 }
@@ -79,9 +79,9 @@ static inline void *gsKit_heap_alloc_dma(GSGLOBAL *gsGlobal, int qsize, int bsiz
 	gsGlobal->CurQueue->same_obj = 0;
 
 	void *p_heap = gsGlobal->CurQueue->pool_cur;
-	(u8*)gsGlobal->CurQueue->pool_cur += bsize;
+	gsGlobal->CurQueue->pool_cur = (void*)((u8*)gsGlobal->CurQueue->pool_cur + bsize);
 	gsGlobal->CurQueue->dma_tag = gsGlobal->CurQueue->pool_cur;
-	(u8*)gsGlobal->CurQueue->pool_cur += 16;
+	gsGlobal->CurQueue->pool_cur = (void*)((u8*)gsGlobal->CurQueue->pool_cur + 16);
 
 	return p_heap;
 }

--- a/ee/toolkit/src/gsToolkit.c
+++ b/ee/toolkit/src/gsToolkit.c
@@ -496,7 +496,7 @@ int  gsKit_texture_tiff(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, char *Path)
 
 	Texture->Mem = memalign(128,TextureSize);
 
-	if (!TIFFReadPS2Image(tif, Texture->Width, Texture->Height, (long unsigned int *)Texture->Mem, 0))
+	if (!TIFFReadPS2Image(tif, Texture->Width, Texture->Height, Texture->Mem, 0))
 	{
 		printf("Error Reading TIFF Data\n");
 		TIFFClose(tif);

--- a/examples/Makefile.global
+++ b/examples/Makefile.global
@@ -38,7 +38,7 @@ endif
 
 EE_LIBS += -lgskit_toolkit
 EE_LIBS += -lgskit -ldmakit
-
+EE_LIBS += -lc -lkenrel
 EE_LIBS += -Xlinker --end-group
 
 # include dir

--- a/examples/Makefile.global
+++ b/examples/Makefile.global
@@ -38,7 +38,7 @@ endif
 
 EE_LIBS += -lgskit_toolkit
 EE_LIBS += -lgskit -ldmakit
-EE_LIBS += -lc -lkenrel
+EE_LIBS += -lc -lkernel
 EE_LIBS += -Xlinker --end-group
 
 # include dir


### PR DESCRIPTION
Fixed Makefile to be a little bit more up-to-date with upstream ps2sdk.
now gskit is compilable under gcc.=v5.3.0
Fixed some warnings and errors