### PR TITLE
Move libc from ps2sdk to newlib

### DIFF
--- a/ee/gs/src/gsCore.c
+++ b/ee/gs/src/gsCore.c
@@ -15,6 +15,7 @@
 #include "gsInline.h"
 
 #include <kernel.h>
+#include <malloc.h>
 
 u32 gsKit_vram_alloc(GSGLOBAL *gsGlobal, u32 size, u8 type)
 {

--- a/ee/gs/src/gsFontM.c
+++ b/ee/gs/src/gsFontM.c
@@ -17,7 +17,11 @@
 //
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
 #include <string.h>
+#include <malloc.h>
+#include <fileio.h>
 
 #include "gsKit.h"
 #include "gsInline.h"

--- a/ee/gs/src/gsHires.c
+++ b/ee/gs/src/gsHires.c
@@ -13,6 +13,7 @@
 #include <gsKit.h>
 #include "gsInline.h"
 #include <kernel.h>
+#include <malloc.h>
 
 
 /*

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -14,6 +14,8 @@
 #include "gsKit.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
 #include <kernel.h>
 #include <osd_config.h>
 

--- a/ee/gs/src/gsTexture.c
+++ b/ee/gs/src/gsTexture.c
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <malloc.h>
 #include <kernel.h>
 
 #include "gsKit.h"

--- a/ee/toolkit/src/gsToolkit.c
+++ b/ee/toolkit/src/gsToolkit.c
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <malloc.h>
 
 #include "gsKit.h"
 #include "gsToolkit.h"


### PR DESCRIPTION
This pull request is 1 of 5 pull requests in 5 different repositories. The goal of these pull requests is to completely remove libc from ps2sdk, and use newlib's libc. The result is both a much smaller codebase (19k lines removed, 1k lines added), and also will the ps2 development environment be a lot more standard. So porting an application to (or from) the ps2 will be more easy.

The interface between newlib and ps2sdk is now in the old ps2sdk/ee/libc folder, that compiles into libps2sdkc.a. All file io functions from newlib can now be used and will automatically map to fio*, or to fileXio* when it's loaded.

The downside to all of this, is that there are some minor incompatibility issues between newlib's libc, and ps2sdk's libc. For instance the include file <stdio.h> in ps2sdk included a lot of things from <unistd.h> and <fcntl.h>. So existing code will have to add a few extra header files. Another more problematic incompatibility is with the file 'open' function, and 'fioOpen' and 'fileXioOpen'. Becouse the flags O_RDONLY, O_WRONLY and O_RDWR have been defined differently in newlib and ps2sdk. This has to be fixed by no longer using fioOpen and fileXioOpen, and only using 'open'. 

This pull request series consists of 5 parts, resulting in a bootable working OPL elf file:
1. ps2toolchain, for removing a lot of hacks and updating the ps2 assembly files in newlib. Upgrading to newer versions of newlib will be a lot simpler after this patch. For now it's updated from v1.10.0 to v1.14.0
2. ps2sdk, mostly for removing libc
3. gsKit, for compatibility
4. ps2sdk-ports, for compatibility
5. open-ps2-loader, for compatbility and a bugfix 

It's likely thhat we will run into some small problems for the next couple of weeks, but I'll be actively trying to fix all the problems that may be caused by these changes.