### PR TITLE
Prepare for newlib, use texture manager and update examples

### DIFF
--- a/ee/gs/include/gsFontM.h
+++ b/ee/gs/include/gsFontM.h
@@ -30,7 +30,7 @@
 #define ALPHA_BLEND_ADD_NOALPHA    (ALPHA(ALPHA_SRC,ALPHA_ZERO,ALPHA_FIX,ALPHA_DST,0x80))
 #define ALPHA_BLEND_ADD    (ALPHA(ALPHA_SRC,ALPHA_ZERO,ALPHA_SRC,ALPHA_DST,0x00))
 
-#define GS_FONTM_PAGE_COUNT 2
+#define GS_FONTM_PAGE_COUNT 8
 
 struct gsKit_fontm_unpack
 {
@@ -61,15 +61,12 @@ typedef struct gsKit_fontm_header GSFONTMHDR;
 /// given font object, regardless of original format or type.
 struct gsFontM
 {
-	GSTEXTURE *Texture;     ///< Font Texture Object
+	GSTEXTURE *Texture[GS_FONTM_PAGE_COUNT]; ///< Font Texture Objects
 	GSFONTMHDR Header;      ///< FONTM Header
-	u32 Vram[GS_FONTM_PAGE_COUNT];	///< FONTM VRAM Allocation (Double Buffered)
 	u32 VramIdx;            ///< FONTM Current Double Buffer Index
-	u32 LastPage[GS_FONTM_PAGE_COUNT];	///< FONTM Last Uploaded Texture Page
 	u8 Align;               ///< FONTM Line Alignment
 	float Spacing;          ///< FONTM Glyph Spacing
 	void *TexBase;          ///< Glyphs Texture Base
-    int pgcount;            /// Number of pages used in one call to gsKit_font_print_scaled
 };
 typedef struct gsFontM GSFONTM;
 
@@ -78,8 +75,10 @@ typedef struct gsFontM GSFONTM;
 extern "C" {
 #endif
 
-/// Initialize Font Object
+/// Create Font Object
 GSFONTM *gsKit_init_fontm();
+/// Free Font Object
+void gsKit_free_fontm(GSGLOBAL *gsGlobal, GSFONTM *gsFontM);
 
 int gsKit_fontm_upload(GSGLOBAL *gsGlobal, GSFONTM *gsFontM);
 int gsKit_fontm_unpack(GSFONTM *gsFontM);

--- a/ee/gs/src/gsCore.c
+++ b/ee/gs/src/gsCore.c
@@ -15,6 +15,7 @@
 #include "gsInline.h"
 
 #include <kernel.h>
+#include <malloc.h>
 
 u32 gsKit_vram_alloc(GSGLOBAL *gsGlobal, u32 size, u8 type)
 {

--- a/ee/gs/src/gsFontM.c
+++ b/ee/gs/src/gsFontM.c
@@ -17,7 +17,11 @@
 //
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
 #include <string.h>
+#include <malloc.h>
+#include <fileio.h>
 
 #include "gsKit.h"
 #include "gsInline.h"

--- a/ee/gs/src/gsHires.c
+++ b/ee/gs/src/gsHires.c
@@ -13,6 +13,7 @@
 #include <gsKit.h>
 #include "gsInline.h"
 #include <kernel.h>
+#include <malloc.h>
 
 
 /*

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -14,6 +14,8 @@
 #include "gsKit.h"
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <malloc.h>
 #include <kernel.h>
 #include <osd_config.h>
 

--- a/ee/gs/src/gsTexManager.c
+++ b/ee/gs/src/gsTexManager.c
@@ -209,7 +209,6 @@ gsKit_TexManager_setmode(GSGLOBAL * gsGlobal, enum ETransferMode mode)
 }
 
 //---------------------------------------------------------------------------
-// FIXME: CLUT textures only work for 8bit textures with a 32bit clut
 unsigned int
 gsKit_TexManager_bind(GSGLOBAL * gsGlobal, GSTEXTURE * tex)
 {
@@ -217,7 +216,9 @@ gsKit_TexManager_bind(GSGLOBAL * gsGlobal, GSTEXTURE * tex)
 	unsigned int ttransfer = 0;
 	unsigned int ctransfer = 0;
 	unsigned int tsize;
-	unsigned int csize;
+	unsigned int csize = 0;
+	unsigned int cwidth = 16;
+	unsigned int cheight = 16;
 
 	// Locate texture
 	for (block = head; block != NULL; block = block->pNext) {
@@ -226,7 +227,11 @@ gsKit_TexManager_bind(GSGLOBAL * gsGlobal, GSTEXTURE * tex)
 	}
 
 	tsize = gsKit_texture_size(tex->Width, tex->Height, tex->PSM);
-	csize = tex->Clut ? 256*4 : 0;
+	if (tex->Clut != NULL) {
+		cwidth  = (tex->PSM == GS_PSM_T8) ? 16 : 8;
+		cheight = (tex->PSM == GS_PSM_T8) ? 16 : 2;
+		csize   = gsKit_texture_size(cwidth, cheight, tex->ClutPSM);
+	}
 
 	// Allocate new block if not already loaded
 	if (block == NULL) {
@@ -261,9 +266,9 @@ gsKit_TexManager_bind(GSGLOBAL * gsGlobal, GSTEXTURE * tex)
 		tex->VramClut = block->iStart + tsize;
 		SyncDCache(tex->Clut, (u8 *)(tex->Clut) + csize);
 		if (trmode == ETM_INLINE)
-			gsKit_texture_send_inline(gsGlobal, tex->Clut, 16, 16, tex->VramClut, tex->ClutPSM, 1, GS_CLUT_PALLETE);
+			gsKit_texture_send_inline(gsGlobal, tex->Clut, cwidth, cheight, tex->VramClut, tex->ClutPSM, 1, GS_CLUT_PALLETE);
 		else
-			gsKit_texture_send(tex->Clut, 16, 16, tex->VramClut, tex->ClutPSM, 1, GS_CLUT_PALLETE);
+			gsKit_texture_send(tex->Clut, cwidth, cheight, tex->VramClut, tex->ClutPSM, 1, GS_CLUT_PALLETE);
 	}
 
 	block->iUseCount++;

--- a/ee/gs/src/gsTexture.c
+++ b/ee/gs/src/gsTexture.c
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <malloc.h>
 #include <kernel.h>
 
 #include "gsKit.h"

--- a/ee/toolkit/src/gsToolkit.c
+++ b/ee/toolkit/src/gsToolkit.c
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <malloc.h>
 
 #include "gsKit.h"
 #include "gsToolkit.h"

--- a/examples/Makefile.global
+++ b/examples/Makefile.global
@@ -55,6 +55,9 @@ all: $(EE_BIN)
 test: all
 	ps2client -h $(PS2_IP) -t 1 execee host:$(EE_BIN)
 
+sim: all
+	PCSX2 --elf=$(PWD)/$(EE_BIN) --nogui
+
 reset: clean
 	ps2client -h $(PS2_IP) reset
 

--- a/examples/alpha/alpha.c
+++ b/examples/alpha/alpha.c
@@ -52,6 +52,7 @@ int main(int argc, char *argv[])
 
 	gsKit_init_screen(gsGlobal);
 #ifdef HAVE_LIBTIFF
+	Sprite.Delayed = 1;
 	if(gsKit_texture_tiff(gsGlobal, &Sprite, "host:alpha.tiff") < 0)
 	{
 		printf("Loading Failed!\n");
@@ -81,6 +82,7 @@ int main(int argc, char *argv[])
 		gsKit_set_primalpha(gsGlobal, GS_SETREG_ALPHA(0,1,0,1,0), 0);
 		gsKit_set_test(gsGlobal, GS_ATEST_OFF);
 #ifdef HAVE_LIBTIFF
+		gsKit_TexManager_bind(gsGlobal, &Sprite);
 		gsKit_prim_sprite_texture(gsGlobal, &Sprite,	310.0f,  // X1
 								50.0f,  // Y2
 								0.0f,  // U1
@@ -100,6 +102,8 @@ int main(int argc, char *argv[])
 		gsKit_queue_exec(gsGlobal);
 
 		gsKit_queue_reset(gsGlobal->Per_Queue);
+
+		gsKit_TexManager_nextFrame(gsGlobal);
 	}
 
 	return 0;

--- a/examples/bigtex/bigtex.c
+++ b/examples/bigtex/bigtex.c
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
         bigtex.Height = 480;
         bigtex.PSM = GS_PSM_CT24;
         bigtex.Filter = GS_FILTER_NEAREST;
+        bigtex.Delayed = 1;
 
 	// gsKit_texture_raw(gsGlobal, &bigtex, "host:bigtex.raw");
 	gsKit_texture_bmp(gsGlobal, &bigtex, "host:bigtex.bmp");
@@ -56,6 +57,7 @@ int main(int argc, char *argv[])
 
 		gsKit_set_clamp(gsGlobal, GS_CMODE_CLAMP);
 
+		gsKit_TexManager_bind(gsGlobal, &bigtex);
 		gsKit_prim_sprite_striped_texture(gsGlobal, &bigtex, x,  // X1
 		// gsKit_prim_sprite_texture(gsGlobal, &bigtex, x,  // X1
 							     0.0f,  // Y2
@@ -71,6 +73,8 @@ int main(int argc, char *argv[])
 		gsKit_queue_exec(gsGlobal);
 
 		gsKit_sync_flip(gsGlobal);
+
+		gsKit_TexManager_nextFrame(gsGlobal);
 
 		if(shrinkx)
 		{

--- a/examples/fontm/fontm.c
+++ b/examples/fontm/fontm.c
@@ -68,10 +68,11 @@ int main(int argc, char *argv[])
 
 	gsFontM->Spacing = 0.95f;
 
+	test.Delayed = 1;
 	gsKit_texture_bmp(gsGlobal, &test, "host:test.bmp");
 	test.Filter = GS_FILTER_LINEAR;
 
-    gsKit_mode_switch(gsGlobal, GS_ONESHOT);
+	gsKit_mode_switch(gsGlobal, GS_ONESHOT);
 
 	while(1)
 	{
@@ -95,7 +96,8 @@ int main(int argc, char *argv[])
 
 		gsKit_clear(gsGlobal, White);
 
-	    gsKit_prim_sprite_texture(gsGlobal, &test,
+		gsKit_TexManager_bind(gsGlobal, &test);
+		gsKit_prim_sprite_texture(gsGlobal, &test,
                                         50.0f, 50.0f, 0.0f, 0.0f,
                                         gsGlobal->Width - 50.0f, gsGlobal->Height - 50.0f,
                                         test.Width, test.Height,
@@ -137,6 +139,7 @@ int main(int argc, char *argv[])
 
 		gsKit_queue_exec(gsGlobal);
 		gsKit_sync_flip(gsGlobal);
+		gsKit_TexManager_nextFrame(gsGlobal);
 	}
 
 	return 0;

--- a/examples/fontm/fontm.c
+++ b/examples/fontm/fontm.c
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
 	// Initialize the DMAC
 	dmaKit_chan_init(DMA_CHANNEL_GIF);
 
-	Black = GS_SETREG_RGBAQ(0x00,0x00,0x00,0x00,0x00);
-	White = GS_SETREG_RGBAQ(0xFF,0xFF,0xFF,0x00,0x00);
+	Black = GS_SETREG_RGBAQ(0x00,0x00,0x00,0x80,0x00);
+	White = GS_SETREG_RGBAQ(0xFF,0xFF,0xFF,0x80,0x00);
 
 	WhiteFont = GS_SETREG_RGBAQ(0x80,0x80,0x80,0x80,0x00);
 	BlackFont = GS_SETREG_RGBAQ(0x00,0x00,0x00,0x80,0x00);
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
 	test.Filter = GS_FILTER_LINEAR;
 
 	gsKit_mode_switch(gsGlobal, GS_ONESHOT);
+	gsKit_set_primalpha(gsGlobal, GS_SETREG_ALPHA(0, 1, 0, 1, 0), 0);
 
 	while(1)
 	{

--- a/examples/hires/main.c
+++ b/examples/hires/main.c
@@ -162,6 +162,12 @@ int render(GSGLOBAL *gsGlobal)
 		// Convert floating point colours to fixed point.
 		draw_convert_rgbq(colors, vertex_count, temp_vertices, temp_colours, 0x80);
 
+#ifndef HIRES_MODE
+		// HIRES mode automatically clears the screen
+		// So only clear the screen in normal mode
+		gsKit_clear(gsGlobal, 0);
+#endif
+
 #ifdef DYNAMIC_DITHERING
 		// Dithering:
 		// The standard 4x4 dithering matrix creates static noise to eliminate banding.

--- a/examples/hires/main.c
+++ b/examples/hires/main.c
@@ -88,7 +88,7 @@ int render(GSGLOBAL *gsGlobal)
 
 #ifdef TEX_BG
 	bigtex.Filter = GS_FILTER_LINEAR;
-	bigtex.Delayed = 0;
+	bigtex.Delayed = 1;
 	gsKit_texture_jpeg(gsGlobal, &bigtex, "host:bigtex.jpg");
 #endif
 
@@ -180,19 +180,18 @@ int render(GSGLOBAL *gsGlobal)
 #endif
 
 #ifdef TEX_BG
-		if(bigtex.Vram != GSKIT_ALLOC_ERROR) {
-			gsKit_prim_sprite_texture(gsGlobal, &bigtex,
-									0.0f,	// X1
-									0.0f,	// Y1
-									0.0f,	// U1
-									0.0f,	// V1
-									gsGlobal->Width,	// X2
-									gsGlobal->Height,	// Y2
-									bigtex.Width,		// U2
-									bigtex.Height,		// V2
-									2,
-									TexCol);
-		}
+		gsKit_TexManager_bind(gsGlobal, &bigtex);
+		gsKit_prim_sprite_texture(gsGlobal, &bigtex,
+			0.0f,	// X1
+			0.0f,	// Y1
+			0.0f,	// U1
+			0.0f,	// V1
+			gsGlobal->Width,	// X2
+			gsGlobal->Height,	// Y2
+			bigtex.Width,		// U2
+			bigtex.Height,		// V2
+			2,
+			TexCol);
 #endif
 
 		for (i = 0; i < points_count; i+=3) {
@@ -211,6 +210,7 @@ int render(GSGLOBAL *gsGlobal)
 		gsKit_queue_exec(gsGlobal);
 		gsKit_sync_flip(gsGlobal);
 #endif
+		gsKit_TexManager_nextFrame(gsGlobal);
 	}
 
 	free(temp_normals);

--- a/examples/modetest/Makefile
+++ b/examples/modetest/Makefile
@@ -11,7 +11,7 @@
 
 EE_BIN  = modetest.elf
 EE_OBJS = modetest.o pad.o
-EE_LIBS = -lpad
+EE_LIBS_EXTRA = -lpad
 
 include ../../Makefile.pref
 include ../Makefile.global

--- a/examples/pixelperfect/pixelperfect.c
+++ b/examples/pixelperfect/pixelperfect.c
@@ -56,8 +56,8 @@ int main(int argc, char *argv[])
 	gsKit_fontm_upload(gsGlobal, gsFontM);
 
 	// Load textures
-	tx128.Delayed = 0;
-	tx132.Delayed = 0;
+	tx128.Delayed = 1;
+	tx132.Delayed = 1;
 	gsKit_texture_png(gsGlobal, &tx128, "host:128x128.png");
 	gsKit_texture_png(gsGlobal, &tx132, "host:132x132.png");
 
@@ -95,70 +95,75 @@ int main(int argc, char *argv[])
 		gsKit_fontm_print_scaled(gsGlobal, gsFontM, 20, 190, 2, 0.5f, Black, "GS_FILTER_LINEAR");
 
 		tx128.Filter = GS_FILTER_NEAREST;
+		gsKit_TexManager_bind(gsGlobal, &tx128);
 		gsKit_prim_sprite_texture(gsGlobal, &tx128,
-								fOffsetX+ 20.0f, // X1
-								fOffsetY+ 40.0f, // Y2
-								fOffsetU+  0.0f, // U1
-								fOffsetV+  0.0f, // V1
-								fOffsetX+tx128.Width  + 20.0f, // X2
-								fOffsetY+tx128.Height + 40.0f, // Y2
-								fOffsetU+tx128.Width,  // U2
-								fOffsetV+tx128.Height, // V2
-								2,
-								TexCol);
+			fOffsetX+ 20.0f, // X1
+			fOffsetY+ 40.0f, // Y2
+			fOffsetU+  0.0f, // U1
+			fOffsetV+  0.0f, // V1
+			fOffsetX+tx128.Width  + 20.0f, // X2
+			fOffsetY+tx128.Height + 40.0f, // Y2
+			fOffsetU+tx128.Width,  // U2
+			fOffsetV+tx128.Height, // V2
+			2,
+			TexCol);
 
 		tx132.Filter = GS_FILTER_NEAREST;
+		gsKit_TexManager_bind(gsGlobal, &tx132);
 		gsKit_prim_sprite_texture(gsGlobal, &tx132,
-								fOffsetX+170.0f, // X1
-								fOffsetY+ 40.0f, // Y2
-								fOffsetU+  2.0f, // U1
-								fOffsetV+  2.0f, // V1
-								fOffsetX+tx132.Width  - 4.0f + 170.0f, // X2
-								fOffsetY+tx132.Height - 4.0f +  40.0f, // Y2
-								fOffsetU+tx132.Width  - 2.0f, // U2
-								fOffsetV+tx132.Height - 2.0f, // V2
-								2,
-								TexCol);
+			fOffsetX+170.0f, // X1
+			fOffsetY+ 40.0f, // Y2
+			fOffsetU+  2.0f, // U1
+			fOffsetV+  2.0f, // V1
+			fOffsetX+tx132.Width  - 4.0f + 170.0f, // X2
+			fOffsetY+tx132.Height - 4.0f +  40.0f, // Y2
+			fOffsetU+tx132.Width  - 2.0f, // U2
+			fOffsetV+tx132.Height - 2.0f, // V2
+			2,
+			TexCol);
 
 		tx128.Filter = GS_FILTER_LINEAR;
+		gsKit_TexManager_bind(gsGlobal, &tx128);
 		gsKit_prim_sprite_texture(gsGlobal, &tx128,
-								fOffsetX+ 20.0f, // X1
-								fOffsetY+210.0f, // Y2
-								fOffsetU+  0.0f, // U1
-								fOffsetV+  0.0f, // V1
-								fOffsetX+tx128.Width  +  20.0f, // X2
-								fOffsetY+tx128.Height + 210.0f, // Y2
-								fOffsetU+tx128.Width,  // U2
-								fOffsetV+tx128.Height, // V2
-								2,
-								TexCol);
+			fOffsetX+ 20.0f, // X1
+			fOffsetY+210.0f, // Y2
+			fOffsetU+  0.0f, // U1
+			fOffsetV+  0.0f, // V1
+			fOffsetX+tx128.Width  +  20.0f, // X2
+			fOffsetY+tx128.Height + 210.0f, // Y2
+			fOffsetU+tx128.Width,  // U2
+			fOffsetV+tx128.Height, // V2
+			2,
+			TexCol);
 
 		tx132.Filter = GS_FILTER_LINEAR;
+		gsKit_TexManager_bind(gsGlobal, &tx132);
 		gsKit_prim_sprite_texture(gsGlobal, &tx132,
-								fOffsetX+170.0f, // X1
-								fOffsetY+210.0f, // Y2
-								fOffsetU+  2.0f, // U1
-								fOffsetV+  2.0f, // V1
-								fOffsetX+tx132.Width  - 4.0f + 170.0f, // X2
-								fOffsetY+tx132.Height - 4.0f + 210.0f, // Y2
-								fOffsetU+tx132.Width  - 2.0f, // U2
-								fOffsetV+tx132.Height - 2.0f, // V2
-								2,
-								TexCol);
+			fOffsetX+170.0f, // X1
+			fOffsetY+210.0f, // Y2
+			fOffsetU+  2.0f, // U1
+			fOffsetV+  2.0f, // V1
+			fOffsetX+tx132.Width  - 4.0f + 170.0f, // X2
+			fOffsetY+tx132.Height - 4.0f + 210.0f, // Y2
+			fOffsetU+tx132.Width  - 2.0f, // U2
+			fOffsetV+tx132.Height - 2.0f, // V2
+			2,
+			TexCol);
 
 		// Magnified to 350x350 pixels
 		tx132.Filter = GS_FILTER_LINEAR;
+		gsKit_TexManager_bind(gsGlobal, &tx132);
 		gsKit_prim_sprite_texture(gsGlobal, &tx132,
-								fOffsetX+320.0f, // X1
-								fOffsetY+ 40.0f, // Y2
-								fOffsetU+  2.0f, // U1
-								fOffsetV+  2.0f, // V1
-								fOffsetX+350.0f + 320.0f, // X2
-								fOffsetY+350.0f +  40.0f, // Y2
-								fOffsetU+tx132.Width  - 2.0f, // U2
-								fOffsetV+tx132.Height - 2.0f, // V2
-								2,
-								TexCol);
+			fOffsetX+320.0f, // X1
+			fOffsetY+ 40.0f, // Y2
+			fOffsetU+  2.0f, // U1
+			fOffsetV+  2.0f, // V1
+			fOffsetX+350.0f + 320.0f, // X2
+			fOffsetY+350.0f +  40.0f, // Y2
+			fOffsetU+tx132.Width  - 2.0f, // U2
+			fOffsetV+tx132.Height - 2.0f, // V2
+			2,
+			TexCol);
 
 		sprintf(tempstr, "fOffsetXY = %.3f %.3f", fOffsetX, fOffsetY);
 		gsKit_fontm_print_scaled(gsGlobal, gsFontM, 20, 400, 2, 0.5f, Black, tempstr);
@@ -167,6 +172,7 @@ int main(int argc, char *argv[])
 
 		gsKit_queue_exec(gsGlobal);
 		gsKit_sync_flip(gsGlobal);
+		gsKit_TexManager_nextFrame(gsGlobal);
 	}
 
 	return 0;

--- a/examples/texstream/texstream.c
+++ b/examples/texstream/texstream.c
@@ -54,19 +54,16 @@ int main(int argc, char *argv[])
 	}
 #endif
 
-	Sprite.Vram = gsKit_vram_alloc(gsGlobal, gsKit_texture_size(Sprite.Width, Sprite.Height, Sprite.PSM), GSKIT_ALLOC_USERBUFFER);
-
 	gsKit_mode_switch(gsGlobal, GS_ONESHOT);
 
 	while(1)
 	{
 		gsKit_clear(gsGlobal, White);
 
-		gsKit_texture_send_inline(gsGlobal, Sprite.Mem, Sprite.Width, Sprite.Height, Sprite.Vram, Sprite.PSM, Sprite.TBW, GS_CLUT_NONE);
-
 		gsKit_set_primalpha(gsGlobal, GS_SETREG_ALPHA(0,1,0,1,0), 0);
 		gsKit_set_test(gsGlobal, GS_ATEST_OFF);
 #ifdef HAVE_LIBPNG
+		gsKit_TexManager_bind(gsGlobal, &Sprite);
 		gsKit_prim_sprite_texture(gsGlobal, &Sprite,	310.0f,  // X1
 								50.0f,  // Y2
 								0.0f,  // U1
@@ -84,6 +81,8 @@ int main(int argc, char *argv[])
 		gsKit_sync_flip(gsGlobal);
 
 		gsKit_queue_exec(gsGlobal);
+
+		gsKit_TexManager_nextFrame(gsGlobal);
 	}
 
 	return 0;


### PR DESCRIPTION
While preparing for the newlib update I've also updated/improved/fixed lots of other projects. These are the gsKit updates:

- add include files required for newlib (and posix compatibility). These changes are compatible with the current toolchain.
- add 4bit clut support to the texture manager. Making it possible to use the texture manager for fontm. This also brings 4bit png support for opl 1 step closer.
- add sim target to example makefile, for easy debugging with pcsx2
- have fontm and examples use the texture manager.
- fix some examples