### PR TITLE
Bugfix for memory corruption when using UCAB memory and minor cleanups

### DIFF
--- a/ee/gs/include/gsCore.h
+++ b/ee/gs/include/gsCore.h
@@ -218,6 +218,12 @@ void gsKit_queue_exec(GSGLOBAL *gsGlobal);
 /// Specific Draw Queue "Execution" (Kicks the Queue passed for the second argument)
 void gsKit_queue_exec_real(GSGLOBAL *gsGlobal, GSQUEUE *Queue);
 
+/// Allocate UCAB buffer in GSQUEUE, internal use only
+void *gsKit_alloc_ucab(int size);
+
+/// Free UCAB buffer in GSQUEUE, internal use only
+void gsKit_free_ucab(void *p);
+
 /// Initialize a Draw Queue (Allocates memory for the Queue)
 void gsKit_queue_init(GSGLOBAL *gsGlobal, GSQUEUE *Queue, u8 mode, int size);
 

--- a/ee/gs/src/gsHires.c
+++ b/ee/gs/src/gsHires.c
@@ -148,7 +148,7 @@ static int hsync_callback()
 	for (iPass = 0; iPass < iPassCount; iPass++) {
 		if (hsync_count == (iYStart + pass[iPass].CRTCBuffer->scanline_begin)) {
 			if (iPass == 0) {
-				// We start rendering the first pass when the CRTS starts
+				// We start rendering the first pass when the CRTC starts
 				// displaying the last pass of the previous field.
 				// So invert to get the current render field.
 				iCurrentRenderField = (((GSREG*)GS_CSR)->FIELD == 1) ? 0 : 1;
@@ -651,7 +651,10 @@ void gsKit_hires_deinit_global(GSGLOBAL *gsGlobal)
 	if (hsync_callback_id >= 0)
 		gsKit_remove_hsync_handler(hsync_callback_id);
 
+	WaitSema(sema_queue_id);
+
 	TerminateThread(ThreadId);
+	DeleteThread(ThreadId);
 
 	if (sema_queue_id >= 0)
 		DeleteSema(sema_queue_id);
@@ -662,6 +665,7 @@ void gsKit_hires_deinit_global(GSGLOBAL *gsGlobal)
 	if (sema_hsync_id >= 0)
 		DeleteSema(sema_hsync_id);
 
+	dmaKit_wait_fast();
 	gsKit_queue_free(gsGlobal, &DrawQueue[1]);
 
 	for (iPass = 0; iPass < iPassCount; iPass++) {
@@ -670,7 +674,4 @@ void gsKit_hires_deinit_global(GSGLOBAL *gsGlobal)
 	}
 
 	gsKit_deinit_global(gsGlobal);
-
-	gsGlobal->CurrentPointer = 0;
-	gsGlobal->TexturePointer = 0;
 }

--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -474,9 +474,7 @@ GSGLOBAL *gsKit_init_global_custom(int Os_AllocSize, int Per_AllocSize)
 	gsGlobal->Clamp = calloc(1,sizeof(GSCLAMP));
 	gsGlobal->Os_Queue = calloc(1,sizeof(GSQUEUE));
 	gsGlobal->Per_Queue = calloc(1,sizeof(GSQUEUE));
-	gsGlobal->dma_misc = (u64 *)((u32)memalign(64, 512) | 0x30000000);
-
-	FlushCache(0);
+	gsGlobal->dma_misc = gsKit_alloc_ucab(512);
 
 	/* Generic Values */
 	if(configGetTvScreenType() == 2) gsGlobal->Aspect = GS_ASPECT_16_9;
@@ -558,9 +556,7 @@ void gsKit_deinit_global(GSGLOBAL *gsGlobal)
 	gsKit_queue_free(gsGlobal, gsGlobal->Per_Queue);
 	gsKit_queue_free(gsGlobal, gsGlobal->Os_Queue);
 
-    gsGlobal->dma_misc = (u64 *)((u32)gsGlobal->dma_misc ^ 0x30000000);
-
-    free(gsGlobal->dma_misc);
+    gsKit_free_ucab(gsGlobal->dma_misc);
     free(gsGlobal->Per_Queue);
     free(gsGlobal->Os_Queue);
     free(gsGlobal->Clamp);


### PR DESCRIPTION
This bugfix will fix memory corruption when mixing cached and non-cached (UCAB) memory. This memory corruption can cause the DMA chain to the GS to become corrupted and can eventually crash the GIF/GS.

gsKit_heap_alloc and gsKit_heap_alloc_dma have been simplified. The alloc functions are now related to the GSQUEUE object, instead of the GSGLOBAL object, making the function smaller and easy to read.

Small gsHires.c cleanups/improvements added during testing.