### PR TITLE
Move libc to newlib

### DIFF
--- a/ee/gs/src/gsFontM.c
+++ b/ee/gs/src/gsFontM.c
@@ -96,8 +96,13 @@ void gsKit_free_fontm(GSGLOBAL *gsGlobal, GSFONTM *gsFontM)
 		free(gsFontM->Texture[pgindx]);
 		gsFontM->Texture[pgindx] = NULL;
 	}
-	free(gsFontM->TexBase);
-	gsFontM->TexBase = NULL;
+
+	if (gsFontM->Header.offset_table != NULL)
+		free(gsFontM->Header.offset_table);
+
+	if (gsFontM->TexBase != NULL)
+		free(gsFontM->TexBase);
+
 	free(gsFontM);
 }
 

--- a/ee/gs/src/gsFontM.c
+++ b/ee/gs/src/gsFontM.c
@@ -19,9 +19,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <string.h>
 #include <malloc.h>
-#include <fileio.h>
 
 #include "gsKit.h"
 #include "gsInline.h"
@@ -130,27 +130,27 @@ int gsKit_fontm_unpack(GSFONTM *gsFontM)
 	void *packed;
 	void *unpacked;
 
-	int FontMFile = fioOpen("rom0:FONTM", O_RDONLY);
+	int FontMFile = open("rom0:FONTM", O_RDONLY);
 	if(FontMFile < 0)
 	{
 		printf("Failed to open FONTM from ROM0\n");
 		return -1;
 	}
 
-	int PackedSize = fioLseek(FontMFile, 0, SEEK_END);
+	int PackedSize = lseek(FontMFile, 0, SEEK_END);
 
-	fioLseek(FontMFile, 0, SEEK_SET);
+	lseek(FontMFile, 0, SEEK_SET);
 
 	packed = malloc(PackedSize);
 
-	if(fioRead(FontMFile, packed, PackedSize) != PackedSize)
+	if(read(FontMFile, packed, PackedSize) != PackedSize)
 	{
 		printf("Error Reading Packed FONTM Data\n");
-		fioClose(FontMFile);
+		close(FontMFile);
 		return -1;
 	}
 
-	fioClose(FontMFile);
+	close(FontMFile);
 
 	struct gsKit_fontm_unpack updata;
 
@@ -165,11 +165,11 @@ int gsKit_fontm_unpack(GSFONTM *gsFontM)
 
 /*
 	// Use this to dump the unpacked fontm file to host:
-	int DumpFile = fioOpen("host:fontm.dump", O_RDWR);
+	int DumpFile = open("host:fontm.dump", O_RDWR);
 
-	fioWrite(DumpFile, unpacked, updata.size);
+	write(DumpFile, unpacked, updata.size);
 
-	fioClose(DumpFile);
+	close(DumpFile);
 */
 
 	gsFontM->Header.sig = *(u32 *)unpacked;


### PR DESCRIPTION
These PR series move libc from ps2sdk to newlib:

**1**: File and directory functions (both fio* and fileXio*) are now handled by newlib, tranparently. With the following functions supported:
-- close/open
-- read/write
-- lseek
-- ioctl
-- unlink (remove)
-- link (rename)
-- mkdir/rmdir
-- stat
-- opendir/closedir
-- readdir
-- rewinddir

Existing code must be modified to use these standard posix function names instead of calling fio* fileXio functions directly, becouse of an incompatibility between newlib and the ps2 file handing. For this reason existing code will provide an error when including ps2 headers that should not be used:

> #error "Using fio/fileXio functions directly in the newlib port will lead to problems."
> #error "Use posix function calls instead."

For some applications however, using the fio*/fileXio* functions directly may still be needed (for instance when mounting partitions). By defining 'NEWLIB_PORT_AWARE' before including these headers this is still possible.
As far as I know the only incompatibility it with opening a file. The flags, like O_RDONLY, are incompatible and must be changed to **FIO**_O_RDONLY.

**2**: time function is implemented, returning the UTC time. Using the stat function the times from files can also be returned in UTC format.

**3**: nanosleep is implemented. It sleeps using SetAlarm. Then busy waits the last nanoseconds, resulting in both a lot of free cpu time, and a very accurate sleep time.

**4**: The linkfile has been moved to the binutils port, and crt0.s has been moved to newlib port.

**5**: The newlib port is upgraded from 1.10 to 1.14. This adds  (amongs other things) wchar support, needed by some applications like uLE. Upgrading to newer versions resulted in a lot of compiler issues. Perhaps newlib can be upgraded to 3.x when the compiler gets updated.

The end result is that porting new applications to the ps2 will become a lot more easy. Or sometimes they will just run.

Special thanks to @fjtrujy, the creator of the PS2 RetroArch port, for making this possible.

---

This PR series consists of ps2toolchain, ps2sdk, ps2sdk-ports and gsKit to get a working newlib toolchain. This is the gsKit PR. It fixes 1 small bug, and the rest is for posix/newlib compatibility.