### PR TITLE
Automate generation of Docker Image

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  repository_dispatch:
+    types: [run_build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: fjtrujy/ps2dev:ps2sdk-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # - name: Install dependencies
+    #   run: |
+    #     apk add gcc musl-dev
+
+    - name: Compile project
+      run: |
+        make clean all install

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: fjtrujy/ps2dev:ps2sdk-latest
+    container: ${{ github.repository_owner }}/ps2sdk:latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install dependencies
+      run: |
+        apk add build-base git
+
     - name: Compile project
       run: |
         make clean all install

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # - name: Install dependencies
-    #   run: |
-    #     apk add gcc musl-dev
-
     - name: Compile project
       run: |
         make clean all install

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,22 @@
+name: CI-Docker
+
+on:
+  push:
+    branches:
+      - master
+  repository_dispatch:
+    types: [run_build]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+  
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: ${{ github.repository_owner }}/ps2dev
+        tags: gskit-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,3 +20,16 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
         repository: ${{ github.repository_owner }}/ps2dev
         tags: gskit-latest
+    
+    - name: Send Compile action
+      run: |
+        export DISPATCH_ACTION="$(echo run_build)"
+        echo "::set-env name=NEW_DISPATCH_ACTION::$DISPATCH_ACTION"
+
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        repository: ${{ github.repository_owner }}/ps2sdk-ports
+        token: ${{ secrets.DISPATCH_TOKEN }}
+        event-type: ${{ env.NEW_DISPATCH_ACTION }}
+        client-payload: '{"ref": "${{ github.ref }}"}'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,8 +18,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repository: ${{ github.repository_owner }}/ps2dev
-        tags: gskit-latest
+        repository: ${{ env.GITHUB_REPOSITORY }}
+        tags: latest
+        build_args: BASE_DOCKER_IMAGE=${{ github.repository_owner }}/ps2sdk:latest
     
     - name: Send Compile action
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM fjtrujy/ps2dev:ps2sdk-latest
 
 ENV GSKIT=$PS2DEV/gsKit
 
-COPY . /src/gskit
+COPY . /src
 
 RUN apk add build-base git
-RUN cd /src/gskit && make all install clean
+RUN cd /src && make all install clean
 
 # Second stage of Dockerfile
 FROM alpine:latest  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM fjtrujy/ps2dev:ps2sdk-latest
+
+ENV GSKIT=$PS2DEV/gsKit
+
+COPY . /src/gskit
+
+RUN \
+  apk add --no-cache --virtual .build-deps gcc musl-dev && \
+  cd /src/gskit && \
+  make && \
+  make install && \
+  make clean && \
+  apk del .build-deps && \
+  rm -rf \
+    /src/* \
+    /tmp/*
+
+WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM fjtrujy/ps2dev:ps2sdk-latest
+ARG BASE_DOCKER_IMAGE
+
+FROM $BASE_DOCKER_IMAGE
 
 ENV GSKIT=$PS2DEV/gsKit
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,15 @@ ENV GSKIT=$PS2DEV/gsKit
 
 COPY . /src/gskit
 
-RUN \
-  cd /src/gskit && \
-  make && \
-  make install && \
-  make clean && \
-  rm -rf \
-    /src/* \
-    /tmp/*
+RUN apk add build-base git
+RUN cd /src/gskit && make all install clean
 
-WORKDIR /src
+# Second stage of Dockerfile
+FROM alpine:latest  
+
+ENV PS2DEV /usr/local/ps2dev
+ENV PS2SDK $PS2DEV/ps2sdk
+ENV PATH   $PATH:${PS2DEV}/bin:${PS2DEV}/ee/bin:${PS2DEV}/iop/bin:${PS2DEV}/dvp/bin:${PS2SDK}/bin
+ENV GSKIT=$PS2DEV/gsKit
+
+COPY --from=0 ${PS2DEV} ${PS2DEV}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,10 @@ ENV GSKIT=$PS2DEV/gsKit
 COPY . /src/gskit
 
 RUN \
-  apk add --no-cache --virtual .build-deps gcc musl-dev && \
   cd /src/gskit && \
   make && \
   make install && \
   make clean && \
-  apk del .build-deps && \
   rm -rf \
     /src/* \
     /tmp/*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
  Licenced under Academic Free License version 2.0
  -----------------------------------------------------------------------
 
+![CI](https://github.com/ps2dev/gsKit/workflows/CI/badge.svg)
+![CI-Docker](https://github.com/ps2dev/gsKit/workflows/CI-Docker/badge.svg)
+
  Introduction
  -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Descriptions
This PR integrates CI/CD in the repo. The main purpose of this CI/CD are:

- Now in advance, if a PR pending to be merged to `Master` is compiling.
- Generate a docker image `ps2dev/gsKit:latest`, for being used latest by https://github.com/ps2dev/gskit as based image.

Additionally, once the docker image is generated, it dispatches an action to `ps2sdk-ports` to notify it for starting the CI/CD process.

In total there is a group of 4 PRs to implement the flow. If we want to have the CI/CD `green` since the beginning we need to merge them **in order and after the previous one finish the workflows**.

The proper order is:

1. https://github.com/ps2dev/ps2toolchain/pull/67
2. https://github.com/ps2dev/ps2sdk/pull/118
3. https://github.com/ps2dev/gsKit/pull/36
4. https://github.com/ps2dev/ps2sdk-ports/pull/50

Everything has been done, thanks to:
- @ooPo for giving me the grants in the `ps2dev` group in `GitHub`.
- @AKuHAK for giving me the grants to the `ps2dev` group in `Docker Hub`
- @rickgaiser for being involved in the whole process since the first minute.


