### PR TITLE
Samples forkflow

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ${{ github.repository_owner }}/ps2sdk:latest
+    container: ps2dev/ps2sdk:latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ps2dev/ps2sdk:latest
+    container: ps2dev/ps2sdk-ports:latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -18,14 +18,24 @@ jobs:
         apk add build-base git
 
     - name: Compile project
+      env:
+        ZLIB: $PS2SDK/ports
+        LIBJPEG: $PS2SDK/ports
+        LIBPNG: $PS2SDK/ports
+        LIBTIFF: $PS2SDK/ports
       run: |
         make clean all install
 
     - name: Compile samples
       if: ${{ success() }}
+      env:
+        ZLIB: $PS2SDK/ports
+        LIBJPEG: $PS2SDK/ports
+        LIBPNG: $PS2SDK/ports
+        LIBTIFF: $PS2SDK/ports
       run: |
         cd examples/
-        make clean all install
+        make clean all
 
     - name: Upload artifacts
       if: ${{ success() }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -20,3 +20,16 @@ jobs:
     - name: Compile project
       run: |
         make clean all install
+
+    - name: Compile samples
+      if: ${{ success() }}
+      run: |
+        cd examples/
+        make clean all install
+
+    - name: Upload artifacts
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: gsKit-samples-${GITHUB_SHA::8}
+        path: examples/

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -17,29 +17,23 @@ jobs:
       run: |
         apk add build-base git
 
-    - name: Compile project
+    - name: Compile project with everything enabled
       env:
-        ZLIB: $PS2SDK/ports
-        LIBJPEG: $PS2SDK/ports
-        LIBPNG: $PS2SDK/ports
-        LIBTIFF: $PS2SDK/ports
+        GSKIT_DEBUG: 1
+        ZLIB: ${PS2SDK}/ports
+        LIBTIFF: ${PS2SDK}/ports
+        LIBJPEG: ${PS2SDK}/ports
+        LIBPNG: ${PS2SDK}/ports
       run: |
         make clean all install
-
-    - name: Compile samples
-      if: ${{ success() }}
-      env:
-        ZLIB: $PS2SDK/ports
-        LIBJPEG: $PS2SDK/ports
-        LIBPNG: $PS2SDK/ports
-        LIBTIFF: $PS2SDK/ports
-      run: |
-        cd examples/
-        make clean all
+    
+    - name: Get short SHA
+      id: slug
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
 
     - name: Upload artifacts
       if: ${{ success() }}
       uses: actions/upload-artifact@v2
       with:
-        name: gsKit-samples-${GITHUB_SHA::8}
-        path: examples/
+        name: gsKit-samples-${{ steps.slug.outputs.sha8 }}
+        path: examples

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
  -----------------------------------------------------------------------
 ```
 
-![CI](https://github.com/ps2dev/gsKit/workflows/CI/badge.svg)
-![CI-Docker](https://github.com/ps2dev/gsKit/workflows/CI-Docker/badge.svg)
+[![CI](https://github.com/ps2dev/gsKit/workflows/CI/badge.svg)](https://github.com/ps2dev/gsKit/actions?query=workflow%3ACI)
+[![CI-Docker](https://github.com/ps2dev/gsKit/workflows/CI-Docker/badge.svg)](https://github.com/ps2dev/gsKit/actions?query=workflow%3ACI-Docker)
 
  ## Introduction
  


### PR DESCRIPTION
Added direct link to workflow logs for badges
Changed from `github.repository_owner` to `ps2dev` so the forks can also use this action.
Enabled everything: debug flag, libpng, libjpg and libtiff
Switched to docker image with ps2sdk-ports