### PR TITLE
Expose SCISSOR register to enable custom scissor boxes

### DIFF
--- a/ee/gs/include/gsCore.h
+++ b/ee/gs/include/gsCore.h
@@ -47,6 +47,9 @@
 /// Resets CLAMP vales to whatever is in gsGlobal->Clamp
 #define GS_CMODE_RESET 0xFF
 
+/// Resets SCISSOR values to the entire display bounds
+#define GS_SCISSOR_RESET 0x00
+
 /// Turns off Z Testing
 #define GS_ZTEST_OFF 0x01
 /// Turns on Z Testing
@@ -155,6 +158,12 @@ void gsKit_set_drawfield(GSGLOBAL *gsGlobal, u8 field);
 /// then draws a sprite with the given color at a Z depth of 0.
 /// It then restores whatever your previous Z Test settings were.
 void gsKit_clear(GSGLOBAL *gsGlobal, u64 Color);
+
+/// Sets the SCISSOR Parameters
+///
+/// GS_SCISSOR_RESET resets scissor box to the entire display;
+/// otherwise, GS_SETREG_SCISSOR() provides a specific box.
+void gsKit_set_scissor(GSGLOBAL *gsGlobal, u64 ScissorBounds);
 
 /// Sets the TEST Parameters
 /// This manipulates the TEST struture of gsGlobal according to

--- a/ee/gs/src/gsCore.c
+++ b/ee/gs/src/gsCore.c
@@ -239,6 +239,22 @@ void gsKit_clear(GSGLOBAL *gsGlobal, u64 color)
 	gsKit_set_test(gsGlobal, 0);
 }
 
+void gsKit_set_scissor(GSGLOBAL *gsGlobal, u64 ScissorBounds) {
+    u64 *p_data;
+	u64 *p_store;
+
+	if (ScissorBounds == GS_SCISSOR_RESET) 
+		ScissorBounds = GS_SETREG_SCISSOR(0, gsGlobal->Width - 1, 0, gsGlobal->Height - 1);
+
+	p_data = p_store = gsKit_heap_alloc(gsGlobal, 1, 16, GIF_AD);
+
+	*p_data++ = GIF_TAG_AD(1);
+	*p_data++ = GIF_AD;
+
+	*p_data++ = ScissorBounds;
+	*p_data++ = GS_SCISSOR_1+gsGlobal->PrimContext;
+}
+
 void gsKit_set_test(GSGLOBAL *gsGlobal, u8 Preset)
 {
 	u64 *p_data;

--- a/examples/basic/basic.c
+++ b/examples/basic/basic.c
@@ -191,7 +191,10 @@ int main(int argc, char *argv[])
 					       180.0f, 350.0f, 5,
 					       Blue, Red, White);
 
+	// Temporarily apply a scissor box that covers only part of the red triangle
+	gsKit_set_scissor(gsGlobal, GS_SETREG_SCISSOR(300.0f, 350.0f, 200.0f, 400.0f));
 	gsKit_prim_triangle(gsGlobal, 300.0f, 200.0f, 300.0f, 350.0f, 400.0f, 350.0f, 3, Red);
+	gsKit_set_scissor(gsGlobal, GS_SCISSOR_RESET);
 
 	gsKit_prim_sprite(gsGlobal, 400.0f, 100.0f, 500.0f, 200.0f, 5, Red);
 


### PR DESCRIPTION
Exposes the SCISSOR register functionality to the gsKit end user. Looks like gsKit initialization was already using the SCISSOR register, but setting it to the full display bounds. This PR allows for setting a custom scissor box, and resetting it to the full display with `GS_SCISSOR_RESET`.

I also added a custom scissor box call to the `basic` sample program. Before and after screenshots are attached -- the red triangle has its drawing clipped due to the scissor box.

![gsKit-scissor-before](https://user-images.githubusercontent.com/479569/150043201-2b26e63b-16cb-412b-b933-b55fbb855b06.png) ![gsKit-scissor-after](https://user-images.githubusercontent.com/479569/150043256-1b01c5e8-cec5-4e53-aedf-5147f9fe8860.png) 

(This scissor box functionality will be super useful to the [PS2 ImGui backend](https://github.com/kbhomes/ps2-imgui-sample) I'm implementing! 😊)