### PR TITLE
Adding functions for render a texture with list of vertices

### DIFF
--- a/ee/gs/include/gsInit.h
+++ b/ee/gs/include/gsInit.h
@@ -1077,6 +1077,14 @@ typedef union {
 	};
 } __attribute__((packed,aligned(8))) gs_rgbaq;
 
+typedef union {
+	u128 uv;
+	struct {
+		u64 coord;
+		u64 tag;
+	};
+} __attribute__((packed,aligned(8))) gs_uv;
+
 /// gsKit Point Primitive Structure
 /// This structure holds all relevant data for any
 /// given point object, regardless of original format or type.
@@ -1086,6 +1094,14 @@ struct gsPrimPoint
 	gs_xyz2 xyz2;
 };
 typedef struct gsPrimPoint GSPRIMPOINT;
+
+struct gsPrimUVPoint
+{
+	gs_rgbaq rgbaq;
+	gs_uv uv;
+	gs_xyz2 xyz2;
+};
+typedef struct gsPrimUVPoint GSPRIMUVPOINT;
 
 /// Alternative Access Method to the GS CSR Register
 struct gsRegisters {

--- a/ee/gs/include/gsInit.h
+++ b/ee/gs/include/gsInit.h
@@ -1061,6 +1061,14 @@ typedef union {
 	};
 } __attribute__((packed,aligned(8))) gs_color_t;
 
+typedef union { 
+    u64 st;
+    struct {
+		float s;
+		float t;
+    };
+} __attribute__((packed, aligned(8))) gs_stq_t;
+
 typedef union {
 	u128 xyz2;
 	struct {
@@ -1085,6 +1093,14 @@ typedef union {
 	};
 } __attribute__((packed,aligned(8))) gs_uv;
 
+typedef union {
+	u128 stq;
+	struct {
+		gs_stq_t st;
+		u64 tag;
+	};
+} __attribute__((packed, aligned(8))) gs_stq;
+
 /// gsKit Point Primitive Structure
 /// This structure holds all relevant data for any
 /// given point object, regardless of original format or type.
@@ -1102,6 +1118,14 @@ struct gsPrimUVPoint
 	gs_xyz2 xyz2;
 };
 typedef struct gsPrimUVPoint GSPRIMUVPOINT;
+
+struct gsPrimSTQPoint
+{
+	gs_rgbaq rgbaq;
+	gs_stq stq;
+	gs_xyz2 xyz2;
+};
+typedef struct gsPrimSTQPoint GSPRIMSTQPOINT;
 
 /// Alternative Access Method to the GS CSR Register
 struct gsRegisters {

--- a/ee/gs/include/gsInit.h
+++ b/ee/gs/include/gsInit.h
@@ -536,6 +536,25 @@
 		((u64)(GS_XYZ2)		<< 40)	| \
 		((u64)(GIF_NOP)		<< 44);
 
+/// Textured Triangle YV Goraud Primitive REGLIST
+#define GIF_TAG_TRIANGLE_GORAUD_TEXTURED_UV_REGS(ctx)   \
+	GIF_TAG_TRIANGLE_GORAUD_TEXTURED_REGS(ctx)
+
+/// Textured Triangle STQ Goraud Primitive REGLIST
+#define GIF_TAG_TRIANGLE_GORAUD_TEXTURED_STQ_REGS(ctx)   \
+		((u64)(GS_TEX0_1 + ctx)	<< 0)	| \
+		((u64)(GS_PRIM)		<< 4)	| \
+		((u64)(GS_RGBAQ)	<< 8)	| \
+		((u64)(GS_ST)		<< 12)	| \
+		((u64)(GS_XYZ2)		<< 16)	| \
+		((u64)(GS_RGBAQ)	<< 20)	| \
+		((u64)(GS_ST)		<< 24)	| \
+		((u64)(GS_XYZ2)		<< 28)	| \
+		((u64)(GS_RGBAQ)	<< 32)	| \
+		((u64)(GS_ST)		<< 36)	| \
+		((u64)(GS_XYZ2)		<< 40)	| \
+		((u64)(GIF_NOP)		<< 44);
+
 // Textured Quad Goraud Primitive
 /// Textured Quad Goraud Primitive GIFTAG
 #define GIF_TAG_QUAD_GORAUD_TEXTURED(NLOOP)   \
@@ -1059,7 +1078,7 @@ typedef union {
 		u8 a;
 		float q;
 	};
-} __attribute__((packed,aligned(8))) gs_color_t;
+} __attribute__((packed,aligned(8))) gs_rgbaq_t;
 
 typedef union { 
     u64 st;
@@ -1080,7 +1099,7 @@ typedef union {
 typedef union {
 	u128 rgbaq;
 	struct {
-		gs_color_t color;
+		gs_rgbaq_t color;
 		u64 tag;
 	};
 } __attribute__((packed,aligned(8))) gs_rgbaq;

--- a/ee/gs/include/gsInline.h
+++ b/ee/gs/include/gsInline.h
@@ -157,29 +157,53 @@ static inline int gsKit_float_to_int_y(const GSGLOBAL *gsGlobal, float fy)
 
 static inline gs_xyz2 vertex_to_XYZ2(const GSGLOBAL *gsGlobal, float fx, float fy, int iz)
 {
-	int ix = gsKit_float_to_int_x(gsGlobal, fx);
-	int iy = gsKit_float_to_int_y(gsGlobal, fy);
+	gs_xyz2 res;
 
-	return (gs_xyz2)(((u128) GS_SETREG_XYZ2(ix, iy, iz)) | (((u128)GS_XYZ2) << 64));
+	res.xyz.x = gsKit_float_to_int_x(gsGlobal, fx);
+	res.xyz.y = gsKit_float_to_int_y(gsGlobal, fy);
+	res.xyz.z = iz;
+	res.tag = GS_XYZ2;
+
+	return res;
 }
 
 // If STQ coordinates are used set q to 1.0f otherwise keep it as 0.0f
 static inline gs_rgbaq color_to_RGBAQ(uint8_t r, uint8_t g, uint8_t b, uint8_t a, float q)
 {
-	return (gs_rgbaq)(((u128) GS_SETREG_RGBAQ(r, g, b, a, *(u32*)(&q))) | (((u128)GS_RGBAQ) << 64));
+	gs_rgbaq res;
+
+	res.color.r = r;
+	res.color.g = g;
+	res.color.b = b;
+	res.color.a = a;
+	res.color.q = q;
+	res.tag = GS_RGBAQ;
+
+	return res;
 }
 
 static inline gs_uv vertex_to_UV(const GSTEXTURE *Texture, float u, float v)
 {
+	gs_uv res;
+
 	int iu = gsKit_float_to_int_u(Texture, u);
 	int iv = gsKit_float_to_int_v(Texture, v);
 
-	return (gs_uv)(((u128) GS_SETREG_UV(iu, iv)) | (((u128)GS_UV) << 64));
+	res.coord = GS_SETREG_UV(iu, iv);
+	res.tag = GS_UV;
+
+	return res;
 }
 
 static inline gs_stq vertex_to_STQ(float s, float t)
 {
-	return (gs_stq)(((u128) GS_SETREG_STQ(*(u32*)(&s), *(u32*)(&t))) | (((u128)GS_ST) << 64));
+	gs_stq res;
+
+	res.st.s = s;
+	res.st.t = t;
+	res.tag = GS_ST;
+
+	return res;
 }
 
 #endif /* __GSINLINE_H__ */

--- a/ee/gs/include/gsInline.h
+++ b/ee/gs/include/gsInline.h
@@ -163,9 +163,10 @@ static inline gs_xyz2 vertex_to_XYZ2(const GSGLOBAL *gsGlobal, float fx, float f
 	return (gs_xyz2)(((u128) GS_SETREG_XYZ2(ix, iy, iz)) | (((u128)GS_XYZ2) << 64));
 }
 
-static inline gs_rgbaq color_to_RGBAQ(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+// If STQ coordinates are used set q to 1.0f otherwise keep it as 0.0f
+static inline gs_rgbaq color_to_RGBAQ(uint8_t r, uint8_t g, uint8_t b, uint8_t a, float q)
 {
-	return (gs_rgbaq)(((u128) GS_SETREG_RGBAQ(r, g, b, a, 0x00)) | (((u128)GS_RGBAQ) << 64));
+	return (gs_rgbaq)(((u128) GS_SETREG_RGBAQ(r, g, b, a, *(u32*)(&q))) | (((u128)GS_RGBAQ) << 64));
 }
 
 static inline gs_uv vertex_to_UV(const GSTEXTURE *Texture, float u, float v)
@@ -174,6 +175,11 @@ static inline gs_uv vertex_to_UV(const GSTEXTURE *Texture, float u, float v)
 	int iv = gsKit_float_to_int_v(Texture, v);
 
 	return (gs_uv)(((u128) GS_SETREG_UV(iu, iv)) | (((u128)GS_UV) << 64));
+}
+
+static inline gs_stq vertex_to_STQ(float s, float t)
+{
+	return (gs_stq)(((u128) GS_SETREG_STQ(*(u32*)(&s), *(u32*)(&t))) | (((u128)GS_ST) << 64));
 }
 
 #endif /* __GSINLINE_H__ */

--- a/ee/gs/include/gsInline.h
+++ b/ee/gs/include/gsInline.h
@@ -168,4 +168,12 @@ static inline gs_rgbaq color_to_RGBAQ(uint8_t r, uint8_t g, uint8_t b, uint8_t a
 	return (gs_rgbaq)(((u128) GS_SETREG_RGBAQ(r, g, b, a, 0x00)) | (((u128)GS_RGBAQ) << 64));
 }
 
+static inline gs_uv vertex_to_UV(const GSTEXTURE *Texture, float u, float v)
+{
+	int iu = gsKit_float_to_int_u(Texture, u);
+	int iv = gsKit_float_to_int_v(Texture, v);
+
+	return (gs_uv)(((u128) GS_SETREG_UV(iu, iv)) | (((u128)GS_UV) << 64));
+}
+
 #endif /* __GSINLINE_H__ */

--- a/ee/gs/include/gsTexture.h
+++ b/ee/gs/include/gsTexture.h
@@ -101,6 +101,8 @@
 
 #define GS_SETREG_UV(u, v) ((u64)(u) | ((u64)(v) << 16))
 
+#define GS_SETREG_STQ(s, t) ((u64)(s) | ((u64)(t) << 32))
+
 #define GS_SETREG_BITBLTBUF(sbp, sbw, spsm, dbp, dbw, dpsm) \
   ((u64)(sbp)         | ((u64)(sbw) << 16) | \
   ((u64)(spsm) << 24) | ((u64)(dbp) << 32) | \
@@ -135,7 +137,8 @@ void gsKit_prim_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Textur
 				float x3, float y3, int iz3, float u3, float v3,
 				u64 color1, u64 color2, u64 color3);
 
-void gsKit_prim_list_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices);
+void gsKit_prim_list_triangle_goraud_texture_uv_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices);
+void gsKit_prim_list_triangle_goraud_texture_stq_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices);
 
 void gsKit_prim_triangle_strip_texture(GSGLOBAL *gsGlobal, GSTEXTURE *Texture,
 					float *TriStrip, int segments, int iz, u64 color);

--- a/ee/gs/include/gsTexture.h
+++ b/ee/gs/include/gsTexture.h
@@ -135,6 +135,8 @@ void gsKit_prim_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Textur
 				float x3, float y3, int iz3, float u3, float v3,
 				u64 color1, u64 color2, u64 color3);
 
+void gsKit_prim_list_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices);
+
 void gsKit_prim_triangle_strip_texture(GSGLOBAL *gsGlobal, GSTEXTURE *Texture,
 					float *TriStrip, int segments, int iz, u64 color);
 

--- a/ee/gs/src/Makefile
+++ b/ee/gs/src/Makefile
@@ -43,9 +43,9 @@ GS_TEXT_MANAGER_OBJS = gsTextManagerInternals.o gsKit_TexManager_init.o gsKit_Te
 GS_TEXTURE_OBJS = gsKit_texture_size_ee.o gsKit_texture_size.o gsKit_texture_to_psm16.o \
 	gsKit_texture_send.o gsKit_texture_send_inline.o gsKit_texture_upload.o gsKit_prim_sprite_texture_3d.o \
 	gsKit_prim_sprite_striped_texture_3d.o gsKit_prim_triangle_texture_3d.o \
-	gsKit_prim_triangle_goraud_texture_3d.o gsKit_prim_list_triangle_goraud_texture_3d.o gsKit_prim_triangle_strip_texture.o \
-	gsKit_prim_triangle_strip_texture_3d.o gsKit_prim_triangle_fan_texture.o gsKit_prim_triangle_fan_texture_3d.o \
-	gsKit_prim_quad_texture_3d.o gsKit_prim_quad_goraud_texture_3d.o
+	gsKit_prim_triangle_goraud_texture_3d.o gsKit_prim_list_triangle_goraud_texture_uv_3d.o gsKit_prim_list_triangle_goraud_texture_stq_3d.o \
+	gsKit_prim_triangle_strip_texture.o gsKit_prim_triangle_strip_texture_3d.o gsKit_prim_triangle_fan_texture.o \
+	gsKit_prim_triangle_fan_texture_3d.o gsKit_prim_quad_texture_3d.o gsKit_prim_quad_goraud_texture_3d.o
 
 GS_VU1_OBJS = 
 

--- a/ee/gs/src/Makefile
+++ b/ee/gs/src/Makefile
@@ -43,7 +43,7 @@ GS_TEXT_MANAGER_OBJS = gsTextManagerInternals.o gsKit_TexManager_init.o gsKit_Te
 GS_TEXTURE_OBJS = gsKit_texture_size_ee.o gsKit_texture_size.o gsKit_texture_to_psm16.o \
 	gsKit_texture_send.o gsKit_texture_send_inline.o gsKit_texture_upload.o gsKit_prim_sprite_texture_3d.o \
 	gsKit_prim_sprite_striped_texture_3d.o gsKit_prim_triangle_texture_3d.o \
-	gsKit_prim_triangle_goraud_texture_3d.o gsKit_prim_triangle_strip_texture.o \
+	gsKit_prim_triangle_goraud_texture_3d.o gsKit_prim_list_triangle_goraud_texture_3d.o gsKit_prim_triangle_strip_texture.o \
 	gsKit_prim_triangle_strip_texture_3d.o gsKit_prim_triangle_fan_texture.o gsKit_prim_triangle_fan_texture_3d.o \
 	gsKit_prim_quad_texture_3d.o gsKit_prim_quad_goraud_texture_3d.o
 

--- a/ee/gs/src/gsTexture.c
+++ b/ee/gs/src/gsTexture.c
@@ -878,7 +878,7 @@ void gsKit_prim_list_triangle_goraud_texture_uv_3d(GSGLOBAL *gsGlobal, GSTEXTURE
 	if(p_store == gsGlobal->CurQueue->last_tag)
 	{
 		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED(count - 1);
-		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED_REGS(gsGlobal->PrimContext);
+		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED_UV_REGS(gsGlobal->PrimContext);
 	}
 
 	if(Texture->VramClut == 0)
@@ -926,7 +926,7 @@ void gsKit_prim_list_triangle_goraud_texture_stq_3d(GSGLOBAL *gsGlobal, GSTEXTUR
 	if(p_store == gsGlobal->CurQueue->last_tag)
 	{
 		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED(count - 1);
-		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED_REGS(gsGlobal->PrimContext);
+		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED_STQ_REGS(gsGlobal->PrimContext);
 	}
 
 	if(Texture->VramClut == 0)

--- a/ee/gs/src/gsTexture.c
+++ b/ee/gs/src/gsTexture.c
@@ -857,8 +857,8 @@ void gsKit_prim_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Textur
 }
 #endif
 
-#if F_gsKit_prim_list_triangle_goraud_texture_3d
-void gsKit_prim_list_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices)
+#if F_gsKit_prim_list_triangle_goraud_texture_uv_3d
+void gsKit_prim_list_triangle_goraud_texture_uv_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices)
 {
 	u64* p_data;
 	u64* p_store;
@@ -898,6 +898,54 @@ void gsKit_prim_list_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *T
 	*p_data++ = GS_SETREG_PRIM( GS_PRIM_PRIM_TRIANGLE, 1, 1, gsGlobal->PrimFogEnable,
 				gsGlobal->PrimAlphaEnable, gsGlobal->PrimAAEnable,
 				1, gsGlobal->PrimContext, 0);
+	
+	*p_data++ = GS_PRIM;
+
+	memcpy(p_data, vertices, bytes);
+}
+#endif
+
+#if F_gsKit_prim_list_triangle_goraud_texture_stq_3d
+void gsKit_prim_list_triangle_goraud_texture_stq_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices)
+{
+	u64* p_data;
+	u64* p_store;
+	int tw, th;
+
+	int qsize = (count*3) + 4;
+	int bytes = count * sizeof(GSPRIMSTQPOINT);
+
+	gsKit_set_texfilter(gsGlobal, Texture->Filter);
+	gsKit_set_tw_th(Texture, &tw, &th);
+
+	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize*16), GIF_AD);
+
+	*p_data++ = GIF_TAG_AD(qsize);
+    *p_data++ = GIF_AD;
+
+	if(p_store == gsGlobal->CurQueue->last_tag)
+	{
+		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED(count - 1);
+		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED_REGS(gsGlobal->PrimContext);
+	}
+
+	if(Texture->VramClut == 0)
+	{
+		*p_data++ = GS_SETREG_TEX0(Texture->Vram/256, Texture->TBW, Texture->PSM,
+			tw, th, gsGlobal->PrimAlphaEnable, 0,
+			0, 0, 0, 0, GS_CLUT_STOREMODE_NOLOAD);
+	}
+	else
+	{
+		*p_data++ = GS_SETREG_TEX0(Texture->Vram/256, Texture->TBW, Texture->PSM,
+			tw, th, gsGlobal->PrimAlphaEnable, 0,
+			Texture->VramClut/256, Texture->ClutPSM, 0, 0, GS_CLUT_STOREMODE_LOAD);
+	}
+	*p_data++ = GS_TEX0_1 + gsGlobal->PrimContext;
+
+	*p_data++ = GS_SETREG_PRIM( GS_PRIM_PRIM_TRIANGLE, 1, 1, gsGlobal->PrimFogEnable,
+				gsGlobal->PrimAlphaEnable, gsGlobal->PrimAAEnable,
+				0, gsGlobal->PrimContext, 0);
 	
 	*p_data++ = GS_PRIM;
 

--- a/ee/gs/src/gsTexture.c
+++ b/ee/gs/src/gsTexture.c
@@ -857,6 +857,54 @@ void gsKit_prim_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Textur
 }
 #endif
 
+#if F_gsKit_prim_list_triangle_goraud_texture_3d
+void gsKit_prim_list_triangle_goraud_texture_3d(GSGLOBAL *gsGlobal, GSTEXTURE *Texture, int count, const void *vertices)
+{
+	u64* p_data;
+	u64* p_store;
+	int tw, th;
+
+	int qsize = (count*3) + 4;
+	int bytes = count * sizeof(GSPRIMUVPOINT);
+
+	gsKit_set_texfilter(gsGlobal, Texture->Filter);
+	gsKit_set_tw_th(Texture, &tw, &th);
+
+	p_store = p_data = gsKit_heap_alloc(gsGlobal, qsize, (qsize*16), GIF_AD);
+
+	*p_data++ = GIF_TAG_AD(qsize);
+    *p_data++ = GIF_AD;
+
+	if(p_store == gsGlobal->CurQueue->last_tag)
+	{
+		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED(count - 1);
+		*p_data++ = GIF_TAG_TRIANGLE_GORAUD_TEXTURED_REGS(gsGlobal->PrimContext);
+	}
+
+	if(Texture->VramClut == 0)
+	{
+		*p_data++ = GS_SETREG_TEX0(Texture->Vram/256, Texture->TBW, Texture->PSM,
+			tw, th, gsGlobal->PrimAlphaEnable, 0,
+			0, 0, 0, 0, GS_CLUT_STOREMODE_NOLOAD);
+	}
+	else
+	{
+		*p_data++ = GS_SETREG_TEX0(Texture->Vram/256, Texture->TBW, Texture->PSM,
+			tw, th, gsGlobal->PrimAlphaEnable, 0,
+			Texture->VramClut/256, Texture->ClutPSM, 0, 0, GS_CLUT_STOREMODE_LOAD);
+	}
+	*p_data++ = GS_TEX0_1 + gsGlobal->PrimContext;
+
+	*p_data++ = GS_SETREG_PRIM( GS_PRIM_PRIM_TRIANGLE, 1, 1, gsGlobal->PrimFogEnable,
+				gsGlobal->PrimAlphaEnable, gsGlobal->PrimAAEnable,
+				1, gsGlobal->PrimContext, 0);
+	
+	*p_data++ = GS_PRIM;
+
+	memcpy(p_data, vertices, bytes);
+}
+#endif
+
 #if F_gsKit_prim_triangle_strip_texture
 void gsKit_prim_triangle_strip_texture(GSGLOBAL *gsGlobal, GSTEXTURE *Texture,
 					float *TriStrip, int segments, int iz, u64 color)

--- a/examples/cube/cube.c
+++ b/examples/cube/cube.c
@@ -178,7 +178,7 @@ int render(GSGLOBAL* gsGlobal)
 
 		for (int i = 0; i < points_count; i++)
 		{
-			gs_vertices[i].rgbaq = color_to_RGBAQ(colors[i].r, colors[i].g, colors[i].b, colors[i].a);
+			gs_vertices[i].rgbaq = color_to_RGBAQ(colors[i].r, colors[i].g, colors[i].b, colors[i].a, 0.0f);
 			gs_vertices[i].xyz2 = vertex_to_XYZ2(gsGlobal, verts[i][0], verts[i][1], verts[i][2]);
 		}
 


### PR DESCRIPTION
I have used a specific SDL example to test performance increase,

![image](https://user-images.githubusercontent.com/10010409/198335571-bfa4d36e-c8a4-48d7-9b40-4f8c0edfe7cd.png)


Before:
`INFO: 469.61 frames per second`
After:
UV -> `INFO: 520.80 frames per second`
ST -> `INFO: 547.89 frames per second`