### PR TITLE
init_screen: Set TA0 alpha to 0, instead of the full 0x80

### DIFF
--- a/ee/gs/src/gsInit.c
+++ b/ee/gs/src/gsInit.c
@@ -450,7 +450,7 @@ void gsKit_init_screen(GSGLOBAL *gsGlobal)
 
 	*p_data++ = GS_DIMX;
 
-	*p_data++ = GS_SETREG_TEXA(0x80, 0, 0x80);
+	*p_data++ = GS_SETREG_TEXA(0x00, 0, 0x80);
 	*p_data++ = GS_TEXA;
 
 	if((gsGlobal->Dithering == GS_SETTING_ON) && ((gsGlobal->PSM == GS_PSM_CT16) || (gsGlobal->PSM == GS_PSM_CT16S))) {


### PR DESCRIPTION
When the texture format is CT16 and `TCC = 1`, the GS will do a look-up into TEXA to determine the output alpha.
The previous behaviour made it so when `A = 0` OR `A = 1` in the input texel, the output alpha would be the full 0x80.
This is kind of a footgun (I've only found this behaviour due to a developer running into an issue with alpha blending).
It's assumable that if your alpha is 0, you would want no output, and that's what the PR achieves.

**If this PR creates an issue where you get no texture output, you should either fix your input texture alpha, or manually set TEXA to your desired (and probably hacky  :^) ) value.**
